### PR TITLE
Unified env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,22 @@
 # podio
 
-## Preparing the environment
+## Prerequisites
 
-### On lxplus
+If you are on lxplus, all the necessary software is preinstalled.
 
-To build and install this package, do:
+On Mac OS or Ubuntu, you need to install the following software. 
 
-    source init.sh
+### ROOT 6.04
 
-### On Mac OS
-
-Assuming the path to your version of ROOT is `<root_path>`, do:
+Install ROOT 6.04 and set up your ROOT environment: 
 
     source <root_path>/bin/thisroot.sh
 
-Set up python. We advise to use the version of python that comes with Mac OS. This version should be 2.7.X
+### Python 2.7
+
+Check the python version by doing:
 
     python --version
-    > Python 2.7.5
 
 Check that the yaml python module is available
 
@@ -26,7 +25,7 @@ Check that the yaml python module is available
 
 If the import goes fine (no message), you're all set. If not, you need to install yaml. For that, you need to:
 
-1- install the C++ yaml library, which is used by the python module. The easiest way to do that is to use homebrew (install homebrew if you don't have it yet)
+1- install the C++ yaml library, which is used by the python module. On Mac OS, The easiest way to do that is to use homebrew (install homebrew if you don't have it yet):
 
     brew install libyaml
 
@@ -36,9 +35,12 @@ If the import goes fine (no message), you're all set. If not, you need to instal
 
 Check that you can now import the yaml module in python.
 
-Finally, set your environment:
 
-    source init_macos.sh
+## Preparing the environment
+
+Before building and installing this package, and everytime you need to use it, do:
+
+    source init.sh
 
 
 ## Compiling

--- a/init.sh
+++ b/init.sh
@@ -7,7 +7,7 @@ export PODIO=$PWD/install
 
 if [[ "$unamestr" == 'Linux' ]]; then
     platform='Linux'
-    if [ -d /afs/cern.ch/sw/lcg ]; then
+    if [[ -d /afs/cern.ch/sw/lcg ]] && [[ `dnsdomainname` = 'cern.ch' ]] ; then
 	#should check domain to make sure we're at CERN
 	#or is this software available somewhere in Lyon? 
 	sw_afs=1

--- a/init.sh
+++ b/init.sh
@@ -1,10 +1,28 @@
-export PATH=/afs/cern.ch/sw/lcg/contrib/CMake/2.8.9/Linux-i386/bin:${PATH}
-source /afs/cern.ch/sw/lcg/contrib/gcc/4.9.3/x86_64-slc6/setup.sh
-source /afs/cern.ch/exp/fcc/sw/0.5/LCG_80/ROOT/6.04.06/x86_64-slc6-gcc49-opt/bin/thisroot.sh
-source /afs/cern.ch/sw/lcg/releases/LCG_80/Python/2.7.9.p1/x86_64-slc6-gcc49-opt/Python-env.sh
-source /afs/cern.ch/sw/lcg/releases/LCG_82/pytools/1.9_python2.7/x86_64-slc6-gcc49-opt/pytools-env.sh
-export CMAKE_PREFIX_PATH=/afs/cern.ch/sw/lcg/releases/gtest/1.7.0-4f83b/x86_64-slc6-gcc49-opt/
+
+platform='unknown'
+sw_afs=0
+unamestr=`uname`
 
 export PODIO=$PWD/install
-export LD_LIBRARY_PATH=$PODIO/tests:$PODIO/lib:$PODIO/examples:$LD_LIBRARY_PATH
+
+if [[ "$unamestr" == 'Linux' ]]; then
+    platform='Linux'
+    if [ -d /afs/cern.ch/sw/lcg ]; then
+	#should check domain to make sure we're at CERN
+	#or is this software available somewhere in Lyon? 
+	sw_afs=1
+	export PATH=/afs/cern.ch/sw/lcg/contrib/CMake/2.8.9/Linux-i386/bin:${PATH}
+	source /afs/cern.ch/sw/lcg/contrib/gcc/4.9.3/x86_64-slc6/setup.sh
+	source /afs/cern.ch/exp/fcc/sw/0.5/LCG_80/ROOT/6.04.06/x86_64-slc6-gcc49-opt/bin/thisroot.sh
+	source /afs/cern.ch/sw/lcg/releases/LCG_80/Python/2.7.9.p1/x86_64-slc6-gcc49-opt/Python-env.sh
+	source /afs/cern.ch/sw/lcg/releases/LCG_82/pytools/1.9_python2.7/x86_64-slc6-gcc49-opt/pytools-env.sh
+	export CMAKE_PREFIX_PATH=/afs/cern.ch/sw/lcg/releases/gtest/1.7.0-4f83b/x86_64-slc6-gcc49-opt/
+	echo cmake and root taken from /afs/cern.ch/sw/lcg
+    fi
+    export LD_LIBRARY_PATH=$PODIO/tests:$PODIO/lib:$PODIO/examples:$LD_LIBRARY_PATH
+elif [[ "$unamestr" == 'Darwin' ]]; then
+    platform='Darwin'
+    export DYLD_LIBRARY_PATH=$PODIO/tests:$PODIO/lib:$PODIO/examples:$DYLD_LIBRARY_PATH
+fi
+echo platform detected: $platform
 export PYTHONPATH=$PODIO/examples:$PODIO/tests:$PYTHONPATH

--- a/init_macos.sh
+++ b/init_macos.sh
@@ -1,3 +1,0 @@
-export PODIO=$PWD/install
-export DYLD_LIBRARY_PATH=$PODIO/examples:$PODIO/tests:$PODIO/lib:$DYLD_LIBRARY_PATH
-export PYTHONPATH=$PODIO/examples:$PODIO/tests:$PYTHONPATH


### PR DESCRIPTION
This PR implements a single init.sh script for all platforms. Tested with the current version of podio on mac os and lxplus, and was tested on ubuntu in the past. 
Similar PRs will follow for fcc-edm, analysis-cpp, pythiafcc. 