### PR TITLE
Fix: Replace forward declaration where full definition is needed

### DIFF
--- a/include/podio/ROOTWriter.h
+++ b/include/podio/ROOTWriter.h
@@ -1,6 +1,8 @@
 #ifndef ROOTWRITER_H
 #define ROOTWRITER_H
 
+#include "podio/EventStore.h"
+
 #include <string>
 #include <vector>
 #include <iostream>
@@ -14,7 +16,6 @@ class TFile;
 namespace podio {
   class CollectionBase;
   class Registry;
-  class EventStore;
 
   class ROOTWriter {
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
 file(GLOB sources *.cc)
-file(GLOB headers ../include/podio/*.h)
+file(GLOB headers ${CMAKE_SOURCE_DIR}/include/podio/*.h)
 REFLEX_GENERATE_DICTIONARY(podio ${headers} SELECTION selection.xml)
 add_library(podioDict SHARED podio.cxx)
 target_link_libraries(podioDict podio ${ROOT_LIBRARIES})


### PR DESCRIPTION
Since the ROOTWriter needs the get implementation in the header file. 