### PR TITLE
Fix to allow EOS input

### DIFF
--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -77,7 +77,7 @@ namespace podio {
   }
 
   void ROOTReader::openFile(const std::string& filename){
-    m_file = new TFile(filename.c_str(),"READ","data file");
+    m_file = TFile::Open(filename.c_str(),"READ","data file");
     if (m_file->IsZombie()) {
       exit(-1);
     }


### PR DESCRIPTION
Using TFile::Open allows to also read eos files.

Accidentally made this PR to hegner/podio before.