### PR TITLE
Fix for relations, additions for reading in FCCSW

### DIFF
--- a/include/podio/CollectionIDTable.h
+++ b/include/podio/CollectionIDTable.h
@@ -27,6 +27,9 @@ namespace podio {
     /// return name for given collection ID
     const std::string name(int collectionID) const;
 
+    /// Check if collection name is known
+    bool present(const std::string& name) const; 
+
     /// register new name to the table
     /// returns assigned collection ID
     int add(const std::string& name);

--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -55,8 +55,11 @@ namespace podio {
     /// empties collections.
     void clearCollections();
 
-    /// clears itself; deletes collections
+    /// clears itself; deletes collections (use at end of event processing)
     void clear();
+
+    /// Clears only the cache containers (use at end of event if ownership of read objects is transferred)
+    void clearCaches();
 
     /// set the reader
     void setReader(IReader* reader);

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -342,9 +342,10 @@ class ClassGenerator(object):
       ConstReferences_template = self.get_template("ConstRefVector.cc.template")
 
       for refvector in refvectors+definition["VectorMembers"]:
+        relnamespace, reltype, _, __ = self.demangle_classname(refvector["type"])
         relationtype = refvector["type"]
         if relationtype not in self.buildin_types and relationtype not in self.reader.components:
-            relationtype = "Const"+relationtype
+            relationtype = relnamespace+"::Const"+reltype
 
         relationName = refvector["name"]
         get_relation = relationName

--- a/src/CollectionIDTable.cc
+++ b/src/CollectionIDTable.cc
@@ -9,14 +9,14 @@ namespace podio {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     auto result = std::find(begin(m_collectionIDs), end(m_collectionIDs), ID);
     auto index = result - m_collectionIDs.begin();
-    return m_names[index];
+    return m_names.at(index);
   }
 
   int CollectionIDTable::collectionID(const std::string& name) const {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     auto result = std::find(begin(m_names), end(m_names), name);
     auto index = result - m_names.begin();
-    return m_collectionIDs[index];
+    return m_collectionIDs.at(index);
   }
 
 

--- a/src/CollectionIDTable.cc
+++ b/src/CollectionIDTable.cc
@@ -9,14 +9,14 @@ namespace podio {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     auto result = std::find(begin(m_collectionIDs), end(m_collectionIDs), ID);
     auto index = result - m_collectionIDs.begin();
-    return m_names.at(index);
+    return m_names[index];
   }
 
   int CollectionIDTable::collectionID(const std::string& name) const {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     auto result = std::find(begin(m_names), end(m_names), name);
     auto index = result - m_names.begin();
-    return m_collectionIDs.at(index);
+    return m_collectionIDs[index];
   }
 
 
@@ -27,6 +27,12 @@ namespace podio {
       std::cout<<"\t"
          <<m_names[i] << " : " << m_collectionIDs[i] <<std::endl;
     }
+  }
+
+  bool CollectionIDTable::present(const std::string& name) const {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    auto result = std::find(begin(m_names), end(m_names), name);
+    return result != end(m_names);
   }
 
   int CollectionIDTable::add(const std::string& name) {

--- a/src/EventStore.cc
+++ b/src/EventStore.cc
@@ -79,11 +79,15 @@ namespace podio {
       coll.second->clear();
       delete coll.second;
     }
-    m_collections.clear();
-    m_retrievedIDs.clear();
     for (auto& coll : m_failedRetrieves){
       delete coll;
     }
+    clearCaches();
+  }
+
+  void EventStore::clearCaches() {
+    m_collections.clear();
+    m_retrievedIDs.clear();
     m_failedRetrieves.clear();
   }
 

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -122,4 +122,6 @@ datatypes :
     Author : "Joschka Lingemann"
     OneToOneRelations :
      - ex::ExampleWithNamespace ref // a ref in a namespace
+    OneToManyRelations :
+     - ex::ExampleWithNamespace refs // multiple refs in a namespace
 

--- a/tests/datamodel/ExampleCluster.h
+++ b/tests/datamodel/ExampleCluster.h
@@ -55,17 +55,17 @@ public:
   void energy(double value);
 
 
-  void addHits(ConstExampleHit);
+  void addHits(::ConstExampleHit);
   unsigned int Hits_size() const;
-  ConstExampleHit Hits(unsigned int) const;
-  std::vector<ConstExampleHit>::const_iterator Hits_begin() const;
-  std::vector<ConstExampleHit>::const_iterator Hits_end() const;
+  ::ConstExampleHit Hits(unsigned int) const;
+  std::vector<::ConstExampleHit>::const_iterator Hits_begin() const;
+  std::vector<::ConstExampleHit>::const_iterator Hits_end() const;
 
-  void addClusters(ConstExampleCluster);
+  void addClusters(::ConstExampleCluster);
   unsigned int Clusters_size() const;
-  ConstExampleCluster Clusters(unsigned int) const;
-  std::vector<ConstExampleCluster>::const_iterator Clusters_begin() const;
-  std::vector<ConstExampleCluster>::const_iterator Clusters_end() const;
+  ::ConstExampleCluster Clusters(unsigned int) const;
+  std::vector<::ConstExampleCluster>::const_iterator Clusters_begin() const;
+  std::vector<::ConstExampleCluster>::const_iterator Clusters_end() const;
 
 
 

--- a/tests/datamodel/ExampleClusterConst.h
+++ b/tests/datamodel/ExampleClusterConst.h
@@ -51,13 +51,13 @@ public:
   const double& energy() const;
 
   unsigned int Hits_size() const;
-  ConstExampleHit Hits(unsigned int) const;
-  std::vector<ConstExampleHit>::const_iterator Hits_begin() const;
-  std::vector<ConstExampleHit>::const_iterator Hits_end() const;
+  ::ConstExampleHit Hits(unsigned int) const;
+  std::vector<::ConstExampleHit>::const_iterator Hits_begin() const;
+  std::vector<::ConstExampleHit>::const_iterator Hits_end() const;
   unsigned int Clusters_size() const;
-  ConstExampleCluster Clusters(unsigned int) const;
-  std::vector<ConstExampleCluster>::const_iterator Clusters_begin() const;
-  std::vector<ConstExampleCluster>::const_iterator Clusters_end() const;
+  ::ConstExampleCluster Clusters(unsigned int) const;
+  std::vector<::ConstExampleCluster>::const_iterator Clusters_begin() const;
+  std::vector<::ConstExampleCluster>::const_iterator Clusters_end() const;
 
 
   /// check whether the object is actually available

--- a/tests/datamodel/ExampleMC.h
+++ b/tests/datamodel/ExampleMC.h
@@ -58,17 +58,17 @@ public:
   void PDG(int value);
 
 
-  void addparents(ConstExampleMC);
+  void addparents(::ConstExampleMC);
   unsigned int parents_size() const;
-  ConstExampleMC parents(unsigned int) const;
-  std::vector<ConstExampleMC>::const_iterator parents_begin() const;
-  std::vector<ConstExampleMC>::const_iterator parents_end() const;
+  ::ConstExampleMC parents(unsigned int) const;
+  std::vector<::ConstExampleMC>::const_iterator parents_begin() const;
+  std::vector<::ConstExampleMC>::const_iterator parents_end() const;
 
-  void adddaughters(ConstExampleMC);
+  void adddaughters(::ConstExampleMC);
   unsigned int daughters_size() const;
-  ConstExampleMC daughters(unsigned int) const;
-  std::vector<ConstExampleMC>::const_iterator daughters_begin() const;
-  std::vector<ConstExampleMC>::const_iterator daughters_end() const;
+  ::ConstExampleMC daughters(unsigned int) const;
+  std::vector<::ConstExampleMC>::const_iterator daughters_begin() const;
+  std::vector<::ConstExampleMC>::const_iterator daughters_end() const;
 
 
 

--- a/tests/datamodel/ExampleMCConst.h
+++ b/tests/datamodel/ExampleMCConst.h
@@ -52,13 +52,13 @@ public:
   const int& PDG() const;
 
   unsigned int parents_size() const;
-  ConstExampleMC parents(unsigned int) const;
-  std::vector<ConstExampleMC>::const_iterator parents_begin() const;
-  std::vector<ConstExampleMC>::const_iterator parents_end() const;
+  ::ConstExampleMC parents(unsigned int) const;
+  std::vector<::ConstExampleMC>::const_iterator parents_begin() const;
+  std::vector<::ConstExampleMC>::const_iterator parents_end() const;
   unsigned int daughters_size() const;
-  ConstExampleMC daughters(unsigned int) const;
-  std::vector<ConstExampleMC>::const_iterator daughters_begin() const;
-  std::vector<ConstExampleMC>::const_iterator daughters_end() const;
+  ::ConstExampleMC daughters(unsigned int) const;
+  std::vector<::ConstExampleMC>::const_iterator daughters_begin() const;
+  std::vector<::ConstExampleMC>::const_iterator daughters_end() const;
 
 
   /// check whether the object is actually available

--- a/tests/datamodel/ExampleReferencingType.h
+++ b/tests/datamodel/ExampleReferencingType.h
@@ -51,17 +51,17 @@ public:
 
 
 
-  void addClusters(ConstExampleCluster);
+  void addClusters(::ConstExampleCluster);
   unsigned int Clusters_size() const;
-  ConstExampleCluster Clusters(unsigned int) const;
-  std::vector<ConstExampleCluster>::const_iterator Clusters_begin() const;
-  std::vector<ConstExampleCluster>::const_iterator Clusters_end() const;
+  ::ConstExampleCluster Clusters(unsigned int) const;
+  std::vector<::ConstExampleCluster>::const_iterator Clusters_begin() const;
+  std::vector<::ConstExampleCluster>::const_iterator Clusters_end() const;
 
-  void addRefs(ConstExampleReferencingType);
+  void addRefs(::ConstExampleReferencingType);
   unsigned int Refs_size() const;
-  ConstExampleReferencingType Refs(unsigned int) const;
-  std::vector<ConstExampleReferencingType>::const_iterator Refs_begin() const;
-  std::vector<ConstExampleReferencingType>::const_iterator Refs_end() const;
+  ::ConstExampleReferencingType Refs(unsigned int) const;
+  std::vector<::ConstExampleReferencingType>::const_iterator Refs_begin() const;
+  std::vector<::ConstExampleReferencingType>::const_iterator Refs_end() const;
 
 
 

--- a/tests/datamodel/ExampleReferencingTypeConst.h
+++ b/tests/datamodel/ExampleReferencingTypeConst.h
@@ -49,13 +49,13 @@ public:
 
 
   unsigned int Clusters_size() const;
-  ConstExampleCluster Clusters(unsigned int) const;
-  std::vector<ConstExampleCluster>::const_iterator Clusters_begin() const;
-  std::vector<ConstExampleCluster>::const_iterator Clusters_end() const;
+  ::ConstExampleCluster Clusters(unsigned int) const;
+  std::vector<::ConstExampleCluster>::const_iterator Clusters_begin() const;
+  std::vector<::ConstExampleCluster>::const_iterator Clusters_end() const;
   unsigned int Refs_size() const;
-  ConstExampleReferencingType Refs(unsigned int) const;
-  std::vector<ConstExampleReferencingType>::const_iterator Refs_begin() const;
-  std::vector<ConstExampleReferencingType>::const_iterator Refs_end() const;
+  ::ConstExampleReferencingType Refs(unsigned int) const;
+  std::vector<::ConstExampleReferencingType>::const_iterator Refs_begin() const;
+  std::vector<::ConstExampleReferencingType>::const_iterator Refs_end() const;
 
 
   /// check whether the object is actually available

--- a/tests/datamodel/ExampleWithARelation.h
+++ b/tests/datamodel/ExampleWithARelation.h
@@ -2,6 +2,8 @@
 #define ExampleWithARelation_H
 #include "ExampleWithARelationData.h"
 #include <vector>
+#include "ExampleWithNamespace.h"
+#include <vector>
 #include "podio/ObjectID.h"
 
 // Type with namespace and namespaced relation
@@ -53,6 +55,12 @@ public:
   const ex::ConstExampleWithNamespace ref() const;
 
   void ref(ex::ConstExampleWithNamespace value);
+
+  void addrefs(ex::ConstExampleWithNamespace);
+  unsigned int refs_size() const;
+  ex::ConstExampleWithNamespace refs(unsigned int) const;
+  std::vector<ex::ConstExampleWithNamespace>::const_iterator refs_begin() const;
+  std::vector<ex::ConstExampleWithNamespace>::const_iterator refs_end() const;
 
 
 

--- a/tests/datamodel/ExampleWithARelationCollection.h
+++ b/tests/datamodel/ExampleWithARelationCollection.h
@@ -114,6 +114,8 @@ private:
   int m_collectionID;
   ExampleWithARelationObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
+  std::vector<ex::ConstExampleWithNamespace>* m_rel_refs; ///< Relation buffer for read / write
+  std::vector<std::vector<ex::ConstExampleWithNamespace>*> m_rel_refs_tmp; ///< Relation buffer for internal book-keeping
   std::vector<ex::ConstExampleWithNamespace>* m_rel_ref; ///< Relation buffer for read / write
 
   // members to handle streaming

--- a/tests/datamodel/ExampleWithARelationConst.h
+++ b/tests/datamodel/ExampleWithARelationConst.h
@@ -2,6 +2,8 @@
 #define ConstExampleWithARelation_H
 #include "ExampleWithARelationData.h"
 #include <vector>
+#include "ExampleWithNamespace.h"
+#include <vector>
 #include "podio/ObjectID.h"
 
 // Type with namespace and namespaced relation
@@ -50,6 +52,10 @@ public:
 
   const ex::ConstExampleWithNamespace ref() const;
 
+  unsigned int refs_size() const;
+  ex::ConstExampleWithNamespace refs(unsigned int) const;
+  std::vector<ex::ConstExampleWithNamespace>::const_iterator refs_begin() const;
+  std::vector<ex::ConstExampleWithNamespace>::const_iterator refs_end() const;
 
 
   /// check whether the object is actually available

--- a/tests/datamodel/ExampleWithARelationData.h
+++ b/tests/datamodel/ExampleWithARelationData.h
@@ -9,7 +9,8 @@
 namespace ex {
 class ExampleWithARelationData {
 public:
-
+  unsigned int refs_begin;
+  unsigned int refs_end;
 };
 } // namespace ex
 

--- a/tests/datamodel/ExampleWithARelationObj.h
+++ b/tests/datamodel/ExampleWithARelationObj.h
@@ -9,6 +9,8 @@
 #include "podio/ObjBase.h"
 #include "ExampleWithARelationData.h"
 
+#include <vector>
+#include "ExampleWithNamespace.h"
 
 
 // forward declarations
@@ -33,6 +35,7 @@ public:
 public:
   ExampleWithARelationData data;
   ::ex::ConstExampleWithNamespace* m_ref;
+  std::vector<::ex::ConstExampleWithNamespace>* m_refs;
 
 
 };

--- a/tests/src/ExampleCluster.cc
+++ b/tests/src/ExampleCluster.cc
@@ -48,13 +48,13 @@ ExampleCluster::operator ConstExampleCluster() const {return ConstExampleCluster
 
 void ExampleCluster::energy(double value){ m_obj->data.energy = value; }
 
-std::vector<ConstExampleHit>::const_iterator ExampleCluster::Hits_begin() const {
+std::vector<::ConstExampleHit>::const_iterator ExampleCluster::Hits_begin() const {
   auto ret_value = m_obj->m_Hits->begin();
   std::advance(ret_value, m_obj->data.Hits_begin);
   return ret_value;
 }
 
-std::vector<ConstExampleHit>::const_iterator ExampleCluster::Hits_end() const {
+std::vector<::ConstExampleHit>::const_iterator ExampleCluster::Hits_end() const {
   auto ret_value = m_obj->m_Hits->begin();
 //fg: this code fails if m_obj->data.Hits==0
 //  std::advance(ret_value, m_obj->data.Hits_end-1);
@@ -63,7 +63,7 @@ std::vector<ConstExampleHit>::const_iterator ExampleCluster::Hits_end() const {
   return ret_value;
 }
 
-void ExampleCluster::addHits(ConstExampleHit component) {
+void ExampleCluster::addHits(::ConstExampleHit component) {
   m_obj->m_Hits->push_back(component);
   m_obj->data.Hits_end++;
 }
@@ -72,19 +72,19 @@ unsigned int ExampleCluster::Hits_size() const {
   return (m_obj->data.Hits_end-m_obj->data.Hits_begin);
 }
 
-ConstExampleHit ExampleCluster::Hits(unsigned int index) const {
+::ConstExampleHit ExampleCluster::Hits(unsigned int index) const {
   if (Hits_size() > index) {
     return m_obj->m_Hits->at(m_obj->data.Hits_begin+index);
   }
   else throw std::out_of_range ("index out of bounds for existing references");
 }
-std::vector<ConstExampleCluster>::const_iterator ExampleCluster::Clusters_begin() const {
+std::vector<::ConstExampleCluster>::const_iterator ExampleCluster::Clusters_begin() const {
   auto ret_value = m_obj->m_Clusters->begin();
   std::advance(ret_value, m_obj->data.Clusters_begin);
   return ret_value;
 }
 
-std::vector<ConstExampleCluster>::const_iterator ExampleCluster::Clusters_end() const {
+std::vector<::ConstExampleCluster>::const_iterator ExampleCluster::Clusters_end() const {
   auto ret_value = m_obj->m_Clusters->begin();
 //fg: this code fails if m_obj->data.Clusters==0
 //  std::advance(ret_value, m_obj->data.Clusters_end-1);
@@ -93,7 +93,7 @@ std::vector<ConstExampleCluster>::const_iterator ExampleCluster::Clusters_end() 
   return ret_value;
 }
 
-void ExampleCluster::addClusters(ConstExampleCluster component) {
+void ExampleCluster::addClusters(::ConstExampleCluster component) {
   m_obj->m_Clusters->push_back(component);
   m_obj->data.Clusters_end++;
 }
@@ -102,7 +102,7 @@ unsigned int ExampleCluster::Clusters_size() const {
   return (m_obj->data.Clusters_end-m_obj->data.Clusters_begin);
 }
 
-ConstExampleCluster ExampleCluster::Clusters(unsigned int index) const {
+::ConstExampleCluster ExampleCluster::Clusters(unsigned int index) const {
   if (Clusters_size() > index) {
     return m_obj->m_Clusters->at(m_obj->data.Clusters_begin+index);
   }

--- a/tests/src/ExampleClusterConst.cc
+++ b/tests/src/ExampleClusterConst.cc
@@ -44,13 +44,13 @@ ConstExampleCluster::~ConstExampleCluster(){
 
   const double& ConstExampleCluster::energy() const { return m_obj->data.energy; }
 
-std::vector<ConstExampleHit>::const_iterator ConstExampleCluster::Hits_begin() const {
+std::vector<::ConstExampleHit>::const_iterator ConstExampleCluster::Hits_begin() const {
   auto ret_value = m_obj->m_Hits->begin();
   std::advance(ret_value, m_obj->data.Hits_begin);
   return ret_value;
 }
 
-std::vector<ConstExampleHit>::const_iterator ConstExampleCluster::Hits_end() const {
+std::vector<::ConstExampleHit>::const_iterator ConstExampleCluster::Hits_end() const {
   auto ret_value = m_obj->m_Hits->begin();
   std::advance(ret_value, m_obj->data.Hits_end-1);
   return ++ret_value;
@@ -60,19 +60,19 @@ unsigned int ConstExampleCluster::Hits_size() const {
   return (m_obj->data.Hits_end-m_obj->data.Hits_begin);
 }
 
-ConstExampleHit ConstExampleCluster::Hits(unsigned int index) const {
+::ConstExampleHit ConstExampleCluster::Hits(unsigned int index) const {
   if (Hits_size() > index) {
     return m_obj->m_Hits->at(m_obj->data.Hits_begin+index);
   }
   else throw std::out_of_range ("index out of bounds for existing references");
 }
-std::vector<ConstExampleCluster>::const_iterator ConstExampleCluster::Clusters_begin() const {
+std::vector<::ConstExampleCluster>::const_iterator ConstExampleCluster::Clusters_begin() const {
   auto ret_value = m_obj->m_Clusters->begin();
   std::advance(ret_value, m_obj->data.Clusters_begin);
   return ret_value;
 }
 
-std::vector<ConstExampleCluster>::const_iterator ConstExampleCluster::Clusters_end() const {
+std::vector<::ConstExampleCluster>::const_iterator ConstExampleCluster::Clusters_end() const {
   auto ret_value = m_obj->m_Clusters->begin();
   std::advance(ret_value, m_obj->data.Clusters_end-1);
   return ++ret_value;
@@ -82,7 +82,7 @@ unsigned int ConstExampleCluster::Clusters_size() const {
   return (m_obj->data.Clusters_end-m_obj->data.Clusters_begin);
 }
 
-ConstExampleCluster ConstExampleCluster::Clusters(unsigned int index) const {
+::ConstExampleCluster ConstExampleCluster::Clusters(unsigned int index) const {
   if (Clusters_size() > index) {
     return m_obj->m_Clusters->at(m_obj->data.Clusters_begin+index);
   }

--- a/tests/src/ExampleMC.cc
+++ b/tests/src/ExampleMC.cc
@@ -50,13 +50,13 @@ ExampleMC::operator ConstExampleMC() const {return ConstExampleMC(m_obj);}
 void ExampleMC::energy(double value){ m_obj->data.energy = value; }
 void ExampleMC::PDG(int value){ m_obj->data.PDG = value; }
 
-std::vector<ConstExampleMC>::const_iterator ExampleMC::parents_begin() const {
+std::vector<::ConstExampleMC>::const_iterator ExampleMC::parents_begin() const {
   auto ret_value = m_obj->m_parents->begin();
   std::advance(ret_value, m_obj->data.parents_begin);
   return ret_value;
 }
 
-std::vector<ConstExampleMC>::const_iterator ExampleMC::parents_end() const {
+std::vector<::ConstExampleMC>::const_iterator ExampleMC::parents_end() const {
   auto ret_value = m_obj->m_parents->begin();
 //fg: this code fails if m_obj->data.parents==0
 //  std::advance(ret_value, m_obj->data.parents_end-1);
@@ -65,7 +65,7 @@ std::vector<ConstExampleMC>::const_iterator ExampleMC::parents_end() const {
   return ret_value;
 }
 
-void ExampleMC::addparents(ConstExampleMC component) {
+void ExampleMC::addparents(::ConstExampleMC component) {
   m_obj->m_parents->push_back(component);
   m_obj->data.parents_end++;
 }
@@ -74,19 +74,19 @@ unsigned int ExampleMC::parents_size() const {
   return (m_obj->data.parents_end-m_obj->data.parents_begin);
 }
 
-ConstExampleMC ExampleMC::parents(unsigned int index) const {
+::ConstExampleMC ExampleMC::parents(unsigned int index) const {
   if (parents_size() > index) {
     return m_obj->m_parents->at(m_obj->data.parents_begin+index);
   }
   else throw std::out_of_range ("index out of bounds for existing references");
 }
-std::vector<ConstExampleMC>::const_iterator ExampleMC::daughters_begin() const {
+std::vector<::ConstExampleMC>::const_iterator ExampleMC::daughters_begin() const {
   auto ret_value = m_obj->m_daughters->begin();
   std::advance(ret_value, m_obj->data.daughters_begin);
   return ret_value;
 }
 
-std::vector<ConstExampleMC>::const_iterator ExampleMC::daughters_end() const {
+std::vector<::ConstExampleMC>::const_iterator ExampleMC::daughters_end() const {
   auto ret_value = m_obj->m_daughters->begin();
 //fg: this code fails if m_obj->data.daughters==0
 //  std::advance(ret_value, m_obj->data.daughters_end-1);
@@ -95,7 +95,7 @@ std::vector<ConstExampleMC>::const_iterator ExampleMC::daughters_end() const {
   return ret_value;
 }
 
-void ExampleMC::adddaughters(ConstExampleMC component) {
+void ExampleMC::adddaughters(::ConstExampleMC component) {
   m_obj->m_daughters->push_back(component);
   m_obj->data.daughters_end++;
 }
@@ -104,7 +104,7 @@ unsigned int ExampleMC::daughters_size() const {
   return (m_obj->data.daughters_end-m_obj->data.daughters_begin);
 }
 
-ConstExampleMC ExampleMC::daughters(unsigned int index) const {
+::ConstExampleMC ExampleMC::daughters(unsigned int index) const {
   if (daughters_size() > index) {
     return m_obj->m_daughters->at(m_obj->data.daughters_begin+index);
   }

--- a/tests/src/ExampleMCConst.cc
+++ b/tests/src/ExampleMCConst.cc
@@ -45,13 +45,13 @@ ConstExampleMC::~ConstExampleMC(){
   const double& ConstExampleMC::energy() const { return m_obj->data.energy; }
   const int& ConstExampleMC::PDG() const { return m_obj->data.PDG; }
 
-std::vector<ConstExampleMC>::const_iterator ConstExampleMC::parents_begin() const {
+std::vector<::ConstExampleMC>::const_iterator ConstExampleMC::parents_begin() const {
   auto ret_value = m_obj->m_parents->begin();
   std::advance(ret_value, m_obj->data.parents_begin);
   return ret_value;
 }
 
-std::vector<ConstExampleMC>::const_iterator ConstExampleMC::parents_end() const {
+std::vector<::ConstExampleMC>::const_iterator ConstExampleMC::parents_end() const {
   auto ret_value = m_obj->m_parents->begin();
   std::advance(ret_value, m_obj->data.parents_end-1);
   return ++ret_value;
@@ -61,19 +61,19 @@ unsigned int ConstExampleMC::parents_size() const {
   return (m_obj->data.parents_end-m_obj->data.parents_begin);
 }
 
-ConstExampleMC ConstExampleMC::parents(unsigned int index) const {
+::ConstExampleMC ConstExampleMC::parents(unsigned int index) const {
   if (parents_size() > index) {
     return m_obj->m_parents->at(m_obj->data.parents_begin+index);
   }
   else throw std::out_of_range ("index out of bounds for existing references");
 }
-std::vector<ConstExampleMC>::const_iterator ConstExampleMC::daughters_begin() const {
+std::vector<::ConstExampleMC>::const_iterator ConstExampleMC::daughters_begin() const {
   auto ret_value = m_obj->m_daughters->begin();
   std::advance(ret_value, m_obj->data.daughters_begin);
   return ret_value;
 }
 
-std::vector<ConstExampleMC>::const_iterator ConstExampleMC::daughters_end() const {
+std::vector<::ConstExampleMC>::const_iterator ConstExampleMC::daughters_end() const {
   auto ret_value = m_obj->m_daughters->begin();
   std::advance(ret_value, m_obj->data.daughters_end-1);
   return ++ret_value;
@@ -83,7 +83,7 @@ unsigned int ConstExampleMC::daughters_size() const {
   return (m_obj->data.daughters_end-m_obj->data.daughters_begin);
 }
 
-ConstExampleMC ConstExampleMC::daughters(unsigned int index) const {
+::ConstExampleMC ConstExampleMC::daughters(unsigned int index) const {
   if (daughters_size() > index) {
     return m_obj->m_daughters->at(m_obj->data.daughters_begin+index);
   }

--- a/tests/src/ExampleReferencingType.cc
+++ b/tests/src/ExampleReferencingType.cc
@@ -42,13 +42,13 @@ ExampleReferencingType::operator ConstExampleReferencingType() const {return Con
 
 
 
-std::vector<ConstExampleCluster>::const_iterator ExampleReferencingType::Clusters_begin() const {
+std::vector<::ConstExampleCluster>::const_iterator ExampleReferencingType::Clusters_begin() const {
   auto ret_value = m_obj->m_Clusters->begin();
   std::advance(ret_value, m_obj->data.Clusters_begin);
   return ret_value;
 }
 
-std::vector<ConstExampleCluster>::const_iterator ExampleReferencingType::Clusters_end() const {
+std::vector<::ConstExampleCluster>::const_iterator ExampleReferencingType::Clusters_end() const {
   auto ret_value = m_obj->m_Clusters->begin();
 //fg: this code fails if m_obj->data.Clusters==0
 //  std::advance(ret_value, m_obj->data.Clusters_end-1);
@@ -57,7 +57,7 @@ std::vector<ConstExampleCluster>::const_iterator ExampleReferencingType::Cluster
   return ret_value;
 }
 
-void ExampleReferencingType::addClusters(ConstExampleCluster component) {
+void ExampleReferencingType::addClusters(::ConstExampleCluster component) {
   m_obj->m_Clusters->push_back(component);
   m_obj->data.Clusters_end++;
 }
@@ -66,19 +66,19 @@ unsigned int ExampleReferencingType::Clusters_size() const {
   return (m_obj->data.Clusters_end-m_obj->data.Clusters_begin);
 }
 
-ConstExampleCluster ExampleReferencingType::Clusters(unsigned int index) const {
+::ConstExampleCluster ExampleReferencingType::Clusters(unsigned int index) const {
   if (Clusters_size() > index) {
     return m_obj->m_Clusters->at(m_obj->data.Clusters_begin+index);
   }
   else throw std::out_of_range ("index out of bounds for existing references");
 }
-std::vector<ConstExampleReferencingType>::const_iterator ExampleReferencingType::Refs_begin() const {
+std::vector<::ConstExampleReferencingType>::const_iterator ExampleReferencingType::Refs_begin() const {
   auto ret_value = m_obj->m_Refs->begin();
   std::advance(ret_value, m_obj->data.Refs_begin);
   return ret_value;
 }
 
-std::vector<ConstExampleReferencingType>::const_iterator ExampleReferencingType::Refs_end() const {
+std::vector<::ConstExampleReferencingType>::const_iterator ExampleReferencingType::Refs_end() const {
   auto ret_value = m_obj->m_Refs->begin();
 //fg: this code fails if m_obj->data.Refs==0
 //  std::advance(ret_value, m_obj->data.Refs_end-1);
@@ -87,7 +87,7 @@ std::vector<ConstExampleReferencingType>::const_iterator ExampleReferencingType:
   return ret_value;
 }
 
-void ExampleReferencingType::addRefs(ConstExampleReferencingType component) {
+void ExampleReferencingType::addRefs(::ConstExampleReferencingType component) {
   m_obj->m_Refs->push_back(component);
   m_obj->data.Refs_end++;
 }
@@ -96,7 +96,7 @@ unsigned int ExampleReferencingType::Refs_size() const {
   return (m_obj->data.Refs_end-m_obj->data.Refs_begin);
 }
 
-ConstExampleReferencingType ExampleReferencingType::Refs(unsigned int index) const {
+::ConstExampleReferencingType ExampleReferencingType::Refs(unsigned int index) const {
   if (Refs_size() > index) {
     return m_obj->m_Refs->at(m_obj->data.Refs_begin+index);
   }

--- a/tests/src/ExampleReferencingTypeConst.cc
+++ b/tests/src/ExampleReferencingTypeConst.cc
@@ -39,13 +39,13 @@ ConstExampleReferencingType::~ConstExampleReferencingType(){
 }
 
 
-std::vector<ConstExampleCluster>::const_iterator ConstExampleReferencingType::Clusters_begin() const {
+std::vector<::ConstExampleCluster>::const_iterator ConstExampleReferencingType::Clusters_begin() const {
   auto ret_value = m_obj->m_Clusters->begin();
   std::advance(ret_value, m_obj->data.Clusters_begin);
   return ret_value;
 }
 
-std::vector<ConstExampleCluster>::const_iterator ConstExampleReferencingType::Clusters_end() const {
+std::vector<::ConstExampleCluster>::const_iterator ConstExampleReferencingType::Clusters_end() const {
   auto ret_value = m_obj->m_Clusters->begin();
   std::advance(ret_value, m_obj->data.Clusters_end-1);
   return ++ret_value;
@@ -55,19 +55,19 @@ unsigned int ConstExampleReferencingType::Clusters_size() const {
   return (m_obj->data.Clusters_end-m_obj->data.Clusters_begin);
 }
 
-ConstExampleCluster ConstExampleReferencingType::Clusters(unsigned int index) const {
+::ConstExampleCluster ConstExampleReferencingType::Clusters(unsigned int index) const {
   if (Clusters_size() > index) {
     return m_obj->m_Clusters->at(m_obj->data.Clusters_begin+index);
   }
   else throw std::out_of_range ("index out of bounds for existing references");
 }
-std::vector<ConstExampleReferencingType>::const_iterator ConstExampleReferencingType::Refs_begin() const {
+std::vector<::ConstExampleReferencingType>::const_iterator ConstExampleReferencingType::Refs_begin() const {
   auto ret_value = m_obj->m_Refs->begin();
   std::advance(ret_value, m_obj->data.Refs_begin);
   return ret_value;
 }
 
-std::vector<ConstExampleReferencingType>::const_iterator ConstExampleReferencingType::Refs_end() const {
+std::vector<::ConstExampleReferencingType>::const_iterator ConstExampleReferencingType::Refs_end() const {
   auto ret_value = m_obj->m_Refs->begin();
   std::advance(ret_value, m_obj->data.Refs_end-1);
   return ++ret_value;
@@ -77,7 +77,7 @@ unsigned int ConstExampleReferencingType::Refs_size() const {
   return (m_obj->data.Refs_end-m_obj->data.Refs_begin);
 }
 
-ConstExampleReferencingType ConstExampleReferencingType::Refs(unsigned int index) const {
+::ConstExampleReferencingType ConstExampleReferencingType::Refs(unsigned int index) const {
   if (Refs_size() > index) {
     return m_obj->m_Refs->at(m_obj->data.Refs_begin+index);
   }

--- a/tests/src/ExampleWithARelation.cc
+++ b/tests/src/ExampleWithARelation.cc
@@ -52,6 +52,36 @@ void ExampleWithARelation::ref(ex::ConstExampleWithNamespace value) {
   m_obj->m_ref = new ConstExampleWithNamespace(value);
 }
 
+std::vector<ex::ConstExampleWithNamespace>::const_iterator ExampleWithARelation::refs_begin() const {
+  auto ret_value = m_obj->m_refs->begin();
+  std::advance(ret_value, m_obj->data.refs_begin);
+  return ret_value;
+}
+
+std::vector<ex::ConstExampleWithNamespace>::const_iterator ExampleWithARelation::refs_end() const {
+  auto ret_value = m_obj->m_refs->begin();
+//fg: this code fails if m_obj->data.refs==0
+//  std::advance(ret_value, m_obj->data.refs_end-1);
+//  return ++ret_value;
+  std::advance(ret_value, m_obj->data.refs_end);
+  return ret_value;
+}
+
+void ExampleWithARelation::addrefs(ex::ConstExampleWithNamespace component) {
+  m_obj->m_refs->push_back(component);
+  m_obj->data.refs_end++;
+}
+
+unsigned int ExampleWithARelation::refs_size() const {
+  return (m_obj->data.refs_end-m_obj->data.refs_begin);
+}
+
+ex::ConstExampleWithNamespace ExampleWithARelation::refs(unsigned int index) const {
+  if (refs_size() > index) {
+    return m_obj->m_refs->at(m_obj->data.refs_begin+index);
+  }
+  else throw std::out_of_range ("index out of bounds for existing references");
+}
 
 
 bool  ExampleWithARelation::isAvailable() const {

--- a/tests/src/ExampleWithARelationCollection.cc
+++ b/tests/src/ExampleWithARelationCollection.cc
@@ -1,5 +1,6 @@
 // standard includes
 #include <stdexcept>
+#include "ExampleWithNamespaceCollection.h" 
 #include "ExampleWithNamespaceCollection.h"
 
 
@@ -7,8 +8,9 @@
 
 namespace ex {
 
-ExampleWithARelationCollection::ExampleWithARelationCollection() : m_isValid(false), m_collectionID(0), m_entries() , m_rel_ref(new std::vector<ex::ConstExampleWithNamespace>()),m_data(new ExampleWithARelationDataContainer() ) {
+ExampleWithARelationCollection::ExampleWithARelationCollection() : m_isValid(false), m_collectionID(0), m_entries() , m_rel_refs(new std::vector<ex::ConstExampleWithNamespace>()), m_rel_ref(new std::vector<ex::ConstExampleWithNamespace>()),m_data(new ExampleWithARelationDataContainer() ) {
     m_refCollections.push_back(new std::vector<podio::ObjectID>());
+  m_refCollections.push_back(new std::vector<podio::ObjectID>());
 
 }
 
@@ -16,6 +18,7 @@ ExampleWithARelationCollection::~ExampleWithARelationCollection() {
   clear();
   if (m_data != nullptr) delete m_data;
     for (auto& pointer : m_refCollections) { if (pointer != nullptr) delete pointer; }
+  if (m_rel_refs != nullptr) { delete m_rel_refs; }
   if (m_rel_ref != nullptr) { delete m_rel_ref; }
 
 };
@@ -35,6 +38,7 @@ int  ExampleWithARelationCollection::size() const {
 ExampleWithARelation ExampleWithARelationCollection::create(){
   auto obj = new ExampleWithARelationObj();
   m_entries.emplace_back(obj);
+  m_rel_refs_tmp.push_back(obj->m_refs);
 
   obj->id = {int(m_entries.size()-1),m_collectionID};
   return ExampleWithARelation(obj);
@@ -43,6 +47,16 @@ ExampleWithARelation ExampleWithARelationCollection::create(){
 void ExampleWithARelationCollection::clear(){
   m_data->clear();
   for (auto& pointer : m_refCollections) { pointer->clear(); }
+  // clear relations to refs. Make sure to unlink() the reference data s they may be gone already.
+  for (auto& pointer : m_rel_refs_tmp) {
+    for(auto& item : (*pointer)) {
+      item.unlink();
+    };
+    delete pointer;
+  }
+  m_rel_refs_tmp.clear();
+  for (auto& item : (*m_rel_refs)) { item.unlink(); }
+  m_rel_refs->clear();
   for (auto& item : (*m_rel_ref)) { item.unlink(); }
   m_rel_ref->clear();
 
@@ -55,15 +69,25 @@ void ExampleWithARelationCollection::prepareForWrite(){
   m_data->reserve(size);
   for (auto& obj : m_entries) {m_data->push_back(obj->data); }
   for (auto& pointer : m_refCollections) {pointer->clear(); } 
+  int refs_index =0;
 
   for(int i=0, size = m_data->size(); i != size; ++i){
+   (*m_data)[i].refs_begin=refs_index;
+   (*m_data)[i].refs_end+=refs_index;
+   refs_index = (*m_data)[refs_index].refs_end;
+   for(auto it : (*m_rel_refs_tmp[i])) {
+     if (it.getObjectID().index == podio::ObjectID::untracked)
+       throw std::runtime_error("Trying to persistify untracked object");
+     m_refCollections[0]->emplace_back(it.getObjectID());
+     m_rel_refs->push_back(it);
+   }
 
   }
   for (auto& obj : m_entries) {
     if (obj->m_ref != nullptr) {
-      m_refCollections[0]->emplace_back(obj->m_ref->getObjectID());
+      m_refCollections[1]->emplace_back(obj->m_ref->getObjectID());
     } else {
-      m_refCollections[0]->push_back({-2,-2});
+      m_refCollections[1]->push_back({-2,-2});
     }
   }
 
@@ -73,7 +97,7 @@ void ExampleWithARelationCollection::prepareAfterRead(){
   int index = 0;
   for (auto& data : *m_data){
     auto obj = new ExampleWithARelationObj({index,m_collectionID}, data);
-    
+        obj->m_refs = m_rel_refs;
     m_entries.emplace_back(obj);
     ++index;
   }
@@ -81,9 +105,17 @@ void ExampleWithARelationCollection::prepareAfterRead(){
 }
 
 bool ExampleWithARelationCollection::setReferences(const podio::ICollectionProvider* collectionProvider){
+  for(unsigned int i=0, size=m_refCollections[0]->size();i!=size;++i) {
+    auto id = (*m_refCollections[0])[i];
+    CollectionBase* coll = nullptr;
+    collectionProvider->get(id.collectionID,coll);
+    ex::ExampleWithNamespaceCollection* tmp_coll = static_cast<ex::ExampleWithNamespaceCollection*>(coll);
+    auto tmp = (*tmp_coll)[id.index];
+    m_rel_refs->emplace_back(tmp);
+  }
 
   for(unsigned int i = 0, size = m_entries.size(); i != size; ++i) {
-    auto id = (*m_refCollections[0])[i];
+    auto id = (*m_refCollections[1])[i];
     if (id.index != podio::ObjectID::invalid) {
       CollectionBase* coll = nullptr;
       collectionProvider->get(id.collectionID,coll);
@@ -103,7 +135,8 @@ void ExampleWithARelationCollection::push_back(ConstExampleWithARelation object)
   if (obj->id.index == podio::ObjectID::untracked) {
       obj->id = {size,m_collectionID};
       m_entries.push_back(obj);
-      
+        m_rel_refs_tmp.push_back(obj->m_refs);
+
   } else {
     throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
   }

--- a/tests/src/ExampleWithARelationConst.cc
+++ b/tests/src/ExampleWithARelationConst.cc
@@ -44,6 +44,28 @@ ConstExampleWithARelation::~ConstExampleWithARelation(){
       return ex::ConstExampleWithNamespace(nullptr);
     }
     return ex::ConstExampleWithNamespace(*(m_obj->m_ref));}
+std::vector<ex::ConstExampleWithNamespace>::const_iterator ConstExampleWithARelation::refs_begin() const {
+  auto ret_value = m_obj->m_refs->begin();
+  std::advance(ret_value, m_obj->data.refs_begin);
+  return ret_value;
+}
+
+std::vector<ex::ConstExampleWithNamespace>::const_iterator ConstExampleWithARelation::refs_end() const {
+  auto ret_value = m_obj->m_refs->begin();
+  std::advance(ret_value, m_obj->data.refs_end-1);
+  return ++ret_value;
+}
+
+unsigned int ConstExampleWithARelation::refs_size() const {
+  return (m_obj->data.refs_end-m_obj->data.refs_begin);
+}
+
+ex::ConstExampleWithNamespace ConstExampleWithARelation::refs(unsigned int index) const {
+  if (refs_size() > index) {
+    return m_obj->m_refs->at(m_obj->data.refs_begin+index);
+  }
+  else throw std::out_of_range ("index out of bounds for existing references");
+}
 
 
 bool  ConstExampleWithARelation::isAvailable() const {

--- a/tests/src/ExampleWithARelationObj.cc
+++ b/tests/src/ExampleWithARelationObj.cc
@@ -5,7 +5,7 @@
 namespace ex {
 ExampleWithARelationObj::ExampleWithARelationObj() :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(),m_ref(nullptr)
-
+, m_refs(new std::vector<::ex::ConstExampleWithNamespace>())
 { }
 
 ExampleWithARelationObj::ExampleWithARelationObj(const podio::ObjectID id, ExampleWithARelationData data) :
@@ -14,11 +14,12 @@ ExampleWithARelationObj::ExampleWithARelationObj(const podio::ObjectID id, Examp
 
 ExampleWithARelationObj::ExampleWithARelationObj(const ExampleWithARelationObj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data)
+    , data(other.data), m_refs(new std::vector<::ex::ConstExampleWithNamespace>(*(other.m_refs)))
 { }
 
 ExampleWithARelationObj::~ExampleWithARelationObj() {
   if (id.index == podio::ObjectID::untracked) {
+    delete m_refs;
 
   }
     if (m_ref != nullptr) delete m_ref;

--- a/tests/src/selection.xml
+++ b/tests/src/selection.xml
@@ -3,418 +3,418 @@
 
           <class name="std::vector<SimpleStruct>" />
 
-          <class name="SimpleStruct">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="SimpleStruct">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ex2::NamespaceInNamespaceStruct>" />
 
-          <class name="ex2::NamespaceInNamespaceStruct">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ex2::NamespaceInNamespaceStruct">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<NotSoSimpleStruct>" />
 
-          <class name="NotSoSimpleStruct">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="NotSoSimpleStruct">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ex2::NamespaceStruct>" />
 
-          <class name="ex2::NamespaceStruct">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ex2::NamespaceStruct">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithStringData>" />
 
-          <class name="ExampleWithStringData">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithStringData">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithString>" />
 
-          <class name="ExampleWithString">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithString">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ConstExampleWithString>" />
 
-          <class name="ConstExampleWithString">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ConstExampleWithString">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithStringCollection>" />
 
-          <class name="ExampleWithStringCollection">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithStringCollection">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithStringObj>" />
 
-          <class name="ExampleWithStringObj">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithStringObj">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ex::ExampleWithARelationData>" />
 
-          <class name="ex::ExampleWithARelationData">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ex::ExampleWithARelationData">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ex::ExampleWithARelation>" />
 
-          <class name="ex::ExampleWithARelation">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ex::ExampleWithARelation">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ex::ConstExampleWithARelation>" />
 
-          <class name="ex::ConstExampleWithARelation">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ex::ConstExampleWithARelation">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ex::ExampleWithARelationCollection>" />
 
-          <class name="ex::ExampleWithARelationCollection">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ex::ExampleWithARelationCollection">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ex::ExampleWithARelationObj>" />
 
-          <class name="ex::ExampleWithARelationObj">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ex::ExampleWithARelationObj">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleMCData>" />
 
-          <class name="ExampleMCData">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleMCData">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleMC>" />
 
-          <class name="ExampleMC">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleMC">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ConstExampleMC>" />
 
-          <class name="ConstExampleMC">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ConstExampleMC">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleMCCollection>" />
 
-          <class name="ExampleMCCollection">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleMCCollection">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleMCObj>" />
 
-          <class name="ExampleMCObj">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleMCObj">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<EventInfoData>" />
 
-          <class name="EventInfoData">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="EventInfoData">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<EventInfo>" />
 
-          <class name="EventInfo">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="EventInfo">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ConstEventInfo>" />
 
-          <class name="ConstEventInfo">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ConstEventInfo">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<EventInfoCollection>" />
 
-          <class name="EventInfoCollection">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="EventInfoCollection">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<EventInfoObj>" />
 
-          <class name="EventInfoObj">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="EventInfoObj">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithComponentData>" />
 
-          <class name="ExampleWithComponentData">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithComponentData">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithComponent>" />
 
-          <class name="ExampleWithComponent">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithComponent">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ConstExampleWithComponent>" />
 
-          <class name="ConstExampleWithComponent">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ConstExampleWithComponent">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithComponentCollection>" />
 
-          <class name="ExampleWithComponentCollection">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithComponentCollection">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithComponentObj>" />
 
-          <class name="ExampleWithComponentObj">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithComponentObj">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleReferencingTypeData>" />
 
-          <class name="ExampleReferencingTypeData">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleReferencingTypeData">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleReferencingType>" />
 
-          <class name="ExampleReferencingType">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleReferencingType">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ConstExampleReferencingType>" />
 
-          <class name="ConstExampleReferencingType">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ConstExampleReferencingType">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleReferencingTypeCollection>" />
 
-          <class name="ExampleReferencingTypeCollection">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleReferencingTypeCollection">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleReferencingTypeObj>" />
 
-          <class name="ExampleReferencingTypeObj">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleReferencingTypeObj">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleHitData>" />
 
-          <class name="ExampleHitData">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleHitData">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleHit>" />
 
-          <class name="ExampleHit">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleHit">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ConstExampleHit>" />
 
-          <class name="ConstExampleHit">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ConstExampleHit">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleHitCollection>" />
 
-          <class name="ExampleHitCollection">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleHitCollection">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleHitObj>" />
 
-          <class name="ExampleHitObj">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleHitObj">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithOneRelationData>" />
 
-          <class name="ExampleWithOneRelationData">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithOneRelationData">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithOneRelation>" />
 
-          <class name="ExampleWithOneRelation">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithOneRelation">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ConstExampleWithOneRelation>" />
 
-          <class name="ConstExampleWithOneRelation">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ConstExampleWithOneRelation">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithOneRelationCollection>" />
 
-          <class name="ExampleWithOneRelationCollection">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithOneRelationCollection">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithOneRelationObj>" />
 
-          <class name="ExampleWithOneRelationObj">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithOneRelationObj">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithVectorMemberData>" />
 
-          <class name="ExampleWithVectorMemberData">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithVectorMemberData">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithVectorMember>" />
 
-          <class name="ExampleWithVectorMember">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithVectorMember">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ConstExampleWithVectorMember>" />
 
-          <class name="ConstExampleWithVectorMember">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ConstExampleWithVectorMember">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithVectorMemberCollection>" />
 
-          <class name="ExampleWithVectorMemberCollection">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithVectorMemberCollection">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleWithVectorMemberObj>" />
 
-          <class name="ExampleWithVectorMemberObj">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleWithVectorMemberObj">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleClusterData>" />
 
-          <class name="ExampleClusterData">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleClusterData">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleCluster>" />
 
-          <class name="ExampleCluster">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleCluster">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ConstExampleCluster>" />
 
-          <class name="ConstExampleCluster">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ConstExampleCluster">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleClusterCollection>" />
 
-          <class name="ExampleClusterCollection">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleClusterCollection">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleClusterObj>" />
 
-          <class name="ExampleClusterObj">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleClusterObj">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ex::ExampleWithNamespaceData>" />
 
-          <class name="ex::ExampleWithNamespaceData">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ex::ExampleWithNamespaceData">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ex::ExampleWithNamespace>" />
 
-          <class name="ex::ExampleWithNamespace">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ex::ExampleWithNamespace">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ex::ConstExampleWithNamespace>" />
 
-          <class name="ex::ConstExampleWithNamespace">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ex::ConstExampleWithNamespace">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ex::ExampleWithNamespaceCollection>" />
 
-          <class name="ex::ExampleWithNamespaceCollection">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ex::ExampleWithNamespaceCollection">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ex::ExampleWithNamespaceObj>" />
 
-          <class name="ex::ExampleWithNamespaceObj">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ex::ExampleWithNamespaceObj">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleForCyclicDependency1Data>" />
 
-          <class name="ExampleForCyclicDependency1Data">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleForCyclicDependency1Data">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleForCyclicDependency1>" />
 
-          <class name="ExampleForCyclicDependency1">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleForCyclicDependency1">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ConstExampleForCyclicDependency1>" />
 
-          <class name="ConstExampleForCyclicDependency1">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ConstExampleForCyclicDependency1">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleForCyclicDependency1Collection>" />
 
-          <class name="ExampleForCyclicDependency1Collection">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleForCyclicDependency1Collection">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleForCyclicDependency1Obj>" />
 
-          <class name="ExampleForCyclicDependency1Obj">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleForCyclicDependency1Obj">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleForCyclicDependency2Data>" />
 
-          <class name="ExampleForCyclicDependency2Data">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleForCyclicDependency2Data">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleForCyclicDependency2>" />
 
-          <class name="ExampleForCyclicDependency2">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleForCyclicDependency2">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ConstExampleForCyclicDependency2>" />
 
-          <class name="ConstExampleForCyclicDependency2">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ConstExampleForCyclicDependency2">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleForCyclicDependency2Collection>" />
 
-          <class name="ExampleForCyclicDependency2Collection">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleForCyclicDependency2Collection">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
           <class name="std::vector<ExampleForCyclicDependency2Obj>" />
 
-          <class name="ExampleForCyclicDependency2Obj">
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-          </class>
+            <class name="ExampleForCyclicDependency2Obj">
+              <field name="m_registry" transient="true"/>
+              <field name="m_container" transient="true"/>
+            </class>
 
 
     </selection>


### PR DESCRIPTION
- OneToManyRelations weren't working if referenced type was namespaces (added test and fixed generator)
- Getting IDs and names from collection table is now done with vector::at instead of vector::operator[] to allow try-catch
- Added a way to clear the containers used for caching in the EventStore only (needed if the ownership of the collections is transferred by the user)