### PR TITLE
Add exposing of POD members to owning class

### DIFF
--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -260,22 +260,23 @@ class ClassGenerator(object):
       for member in definition["Members"]:
         name = member["name"]
         klass = member["type"]
+        desc = member["description"]
         gname,sname = name,name
         if( self.getSyntax ):
           gname = "get" + name[:1].upper() + name[1:]
           sname = "set" + name[:1].upper() + name[1:]
-        getter_declarations += declarations["member_getter"].format(type=klass, name=name,fname=gname)
+        getter_declarations += declarations["member_getter"].format(type=klass, name=name,fname=gname, description=desc)
         getter_implementations += implementations["member_getter"].format(type=klass, classname=rawclassname, name=name, fname=gname)
         if klass in self.buildin_types:
-          setter_declarations += declarations["member_builtin_setter"].format(type=klass, name=name, fname=sname)
+          setter_declarations += declarations["member_builtin_setter"].format(type=klass, name=name, fname=sname, description=desc)
           setter_implementations += implementations["member_builtin_setter"].format(type=klass, classname=rawclassname, name=name, fname=sname)
         else:
-          setter_declarations += declarations["member_class_refsetter"].format(type=klass, name=name)
+          setter_declarations += declarations["member_class_refsetter"].format(type=klass, name=name, description=desc)
           setter_implementations += implementations["member_class_refsetter"].format(type=klass, classname=rawclassname, name=name, fname=sname)
-          setter_declarations += declarations["member_class_setter"].format(type=klass, name=name, fname=sname)
+          setter_declarations += declarations["member_class_setter"].format(type=klass, name=name, fname=sname, description=desc)
           setter_implementations += implementations["member_class_setter"].format(type=klass, classname=rawclassname, name=name, fname=sname)
         # Getter for the Const variety of this datatype
-        ConstGetter_implementations += implementations["const_member_getter"].format(type=klass, classname=rawclassname, name=name, fname=gname)
+        ConstGetter_implementations += implementations["const_member_getter"].format(type=klass, classname=rawclassname, name=name, fname=gname, description=desc)
 
 
         # set up signature
@@ -287,15 +288,16 @@ class ClassGenerator(object):
       for member in oneToOneRelations:
           name = member["name"]
           klass = member["type"]
+          desc = member["description"]
           mnamespace = ""
           klassname = klass
           mnamespace, klassname, _, __ = self.demangle_classname(klass)
 
-          setter_declarations += declarations["one_rel_setter"].format(name=name, namespace=mnamespace, type=klassname)
+          setter_declarations += declarations["one_rel_setter"].format(name=name, namespace=mnamespace, type=klassname, description=desc)
           setter_implementations += implementations["one_rel_setter"].format(name=name, namespace=mnamespace, type=klassname, classname=rawclassname)
-          getter_declarations += declarations["one_rel_getter"].format(name=name, namespace=mnamespace, type=klassname)
+          getter_declarations += declarations["one_rel_getter"].format(name=name, namespace=mnamespace, type=klassname, description=desc)
           getter_implementations += implementations["one_rel_getter"].format(name=name, namespace=mnamespace, type=klassname, classname=rawclassname)
-          ConstGetter_implementations += implementations["const_one_rel_getter"].format(name=name, namespace=mnamespace, type=klassname, classname=rawclassname)
+          ConstGetter_implementations += implementations["const_one_rel_getter"].format(name=name, namespace=mnamespace, type=klassname, classname=rawclassname, description=desc)
 
 
       # handle vector members

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -296,6 +296,7 @@ class ClassGenerator(object):
                 setter_implementations += implementations["pod_member_class_refsetter"].format(type=comp_member_class, classname=rawclassname, name=comp_member_name, fname=comp_sname, compname=name)
                 setter_declarations += declarations["pod_member_class_setter"].format(type=comp_member_class, name=comp_member_name, fname=comp_sname, compname=name)
                 setter_implementations += implementations["pod_member_class_setter"].format(type=comp_member_class, classname=rawclassname, fname=comp_sname, name=comp_member_name, compname=name)
+              ConstGetter_implementations += implementations["const_pod_member_getter"].format(type=comp_member_class, classname=rawclassname, name=comp_member_name, fname=comp_gname, compname=name)
 
         # Getter for the Const variety of this datatype
         ConstGetter_implementations += implementations["const_member_getter"].format(type=klass, classname=rawclassname, name=name, fname=gname, description=desc)

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -33,14 +33,13 @@ _text_ = """
 class ClassGenerator(object):
 
     def __init__(self, yamlfile, install_dir, package_name,
-                 verbose=True, getSyntax=False):
+                 verbose=True):
 
         self.yamlfile = yamlfile
         self.install_dir = install_dir
         self.package_name = package_name
         self.template_dir = os.path.join(thisdir, "../templates")
         self.verbose = verbose
-        self.getSyntax = getSyntax
         self.buildin_types = ClassDefinitionValidator.buildin_types
         self.created_classes = []
         self.requested_classes = []
@@ -50,6 +49,8 @@ class ClassGenerator(object):
 
     def process(self):
         self.reader.read()
+        self.getSyntax = self.reader.options["getSyntax"]
+        self.expose_pod_members = self.reader.options["exposePODMembers"]
         self.process_components(self.reader.components)
         self.process_datatypes(self.reader.datatypes)
         self.create_selection_xml()
@@ -276,7 +277,7 @@ class ClassGenerator(object):
           setter_implementations += implementations["member_class_refsetter"].format(type=klass, classname=rawclassname, name=name, fname=sname)
           setter_declarations += declarations["member_class_setter"].format(type=klass, name=name, fname=sname, description=desc)
           setter_implementations += implementations["member_class_setter"].format(type=klass, classname=rawclassname, name=name, fname=sname)
-          if True: # TODO: add definition of this switch
+          if self.expose_pod_members:
             sub_members = self.component_members[klass]
             for sub_member in sub_members:
               comp_member_class, comp_member_name = sub_member
@@ -809,7 +810,7 @@ if __name__ == "__main__":
   if not os.path.exists( directory ):
     os.makedirs(directory)
 
-  gen = ClassGenerator(args[0], args[1], args[2], verbose = options.verbose, getSyntax=options.getSyntax )
+  gen = ClassGenerator(args[0], args[1], args[2], verbose = options.verbose)
   gen.process()
   for warning in gen.warnings:
       print warning

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -100,6 +100,11 @@ class PodioConfigReader(object):
         self.yamlfile = yamlfile
         self.datatypes = {}
         self.components = {}
+        self.options = {
+            # should getters / setters be prefixed with get / set?
+            "getSyntax": False,
+            # should POD members be exposed with getters/setters in classes that have them as members?
+            "exposePODMembers": True}
 
     @staticmethod
     def handle_extracode(definition):
@@ -140,3 +145,6 @@ class PodioConfigReader(object):
             for klassname, value in content["components"].iteritems():
                 component = {"Members": value}
                 self.components[klassname] = component
+        if "options" in content.keys():
+            for option, value in content["options"].iteritems():
+                self.options[option] = value in ["True", "true", "TRUE", "On", "on", "ON"]

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -147,4 +147,4 @@ class PodioConfigReader(object):
                 self.components[klassname] = component
         if "options" in content.keys():
             for option, value in content["options"].iteritems():
-                self.options[option] = value in ["True", "true", "TRUE", "On", "on", "ON"]
+                self.options[option] = value

--- a/python/podio_templates.py
+++ b/python/podio_templates.py
@@ -46,6 +46,9 @@ implementations["pod_member_class_refsetter"] = "{type}& {classname}::{name}() {
 declarations["pod_member_class_setter"] = "\tvoid {fname}(class {type} value);\n"
 implementations["pod_member_class_setter"] = "void {classname}::{fname}(class {type} value) {{ m_obj->data.{compname}.{name} = value; }}\n"
 
+# this is inline, don't need the declaration
+# implementations["const_member_getter"] =  "\t/// Access the {description}\n"
+implementations["const_pod_member_getter"] = "\tconst {type}& Const{classname}::{fname}() const {{ return m_obj->data.{compname}.{name}; }}\n"
 
 # OneToOneRelations
 #-----------------------------------

--- a/python/podio_templates.py
+++ b/python/podio_templates.py
@@ -13,10 +13,12 @@ implementations["member_getter"] = "\tconst {type}& {classname}::{fname}() const
 declarations["member_builtin_setter"] =  "\t/// Set the {description}\n"
 declarations["member_builtin_setter"] += "\tvoid {fname}({type} value);\n\n"
 implementations["member_builtin_setter"] = "void {classname}::{fname}({type} value){{ m_obj->data.{name} = value; }}\n"
+
 # conceptually getting a non-const ref is a setter:
 declarations["member_class_refsetter"] =  "\t/// Get reference to the {description}\n"
 declarations["member_class_refsetter"] += "\t{type}& {name}();\n"
 implementations["member_class_refsetter"] = "\t{type}& {classname}::{name}() {{ return m_obj->data.{name}; }}\n"
+
 declarations["member_class_setter"] =  "\t/// Set the {description}\n"
 declarations["member_class_setter"] += "\tvoid {fname}(class {type} value);\n"
 implementations["member_class_setter"] = "void {classname}::{fname}(class {type} value) {{ m_obj->data.{name} = value; }}\n"
@@ -24,6 +26,26 @@ implementations["member_class_setter"] = "void {classname}::{fname}(class {type}
 # this is inline, don't need the declaration
 implementations["const_member_getter"] =  "\t/// Access the {description}\n"
 implementations["const_member_getter"] += "\tconst {type}& Const{classname}::{fname}() const {{ return m_obj->data.{name}; }}\n"
+
+
+# currently no description of the POD members this could be re-added then
+# declarations["pod_member_getter"] =  "\t/// Access the {description}\n"
+declarations["pod_member_getter"] = "\tconst {type}& {fname}() const;\n"
+implementations["pod_member_getter"] = "const {type}& {classname}::{fname}() const {{ return m_obj->data.{compname}.{name}; }}\n"
+
+# declarations["pod_member_builtin_setter"] =  "\t/// Set the {description}\n"
+declarations["pod_member_builtin_setter"] = "\tvoid {fname}({type} value);\n\n"
+implementations["pod_member_builtin_setter"] = "void {classname}::{fname}({type} value){{ m_obj->data.{compname}.{name} = value; }}\n"
+
+# conceptually getting a non-const ref is a setter:
+# declarations["pod_member_class_refsetter"] =  "\t/// Get reference to the {description}\n"
+declarations["pod_member_class_refsetter"] = "\t{type}& {name}();\n"
+implementations["pod_member_class_refsetter"] = "{type}& {classname}::{name}() {{ return m_obj->data.{compname}.{name}; }}\n"
+
+# declarations["pod_member_class_setter"] =  "\t/// Set the {description}\n"
+declarations["pod_member_class_setter"] = "\tvoid {fname}(class {type} value);\n"
+implementations["pod_member_class_setter"] = "void {classname}::{fname}(class {type} value) {{ m_obj->data.{compname}.{name} = value; }}\n"
+
 
 # OneToOneRelations
 #-----------------------------------

--- a/python/podio_templates.py
+++ b/python/podio_templates.py
@@ -6,35 +6,43 @@ arguments = {}
 
 # Members
 #-----------------------------------
-declarations["member_getter"] = "\tconst {type}& {fname}() const;\n"
+declarations["member_getter"] =  "\t/// Access the {description}\n"
+declarations["member_getter"] += "\tconst {type}& {fname}() const;\n"
 implementations["member_getter"] = "\tconst {type}& {classname}::{fname}() const {{ return m_obj->data.{name}; }}\n"
 
-declarations["member_builtin_setter"] = "\tvoid {fname}({type} value);\n\n"
+declarations["member_builtin_setter"] =  "\t/// Set the {description}\n"
+declarations["member_builtin_setter"] += "\tvoid {fname}({type} value);\n\n"
 implementations["member_builtin_setter"] = "void {classname}::{fname}({type} value){{ m_obj->data.{name} = value; }}\n"
 # conceptually getting a non-const ref is a setter:
-declarations["member_class_refsetter"] = "\t{type}& {name}();\n"
+declarations["member_class_refsetter"] =  "\t/// Get reference to the {description}\n"
+declarations["member_class_refsetter"] += "\t{type}& {name}();\n"
 implementations["member_class_refsetter"] = "\t{type}& {classname}::{name}() {{ return m_obj->data.{name}; }}\n"
-declarations["member_class_setter"] = "\tvoid {fname}(class {type} value);\n"
+declarations["member_class_setter"] =  "\t/// Set the {description}\n"
+declarations["member_class_setter"] += "\tvoid {fname}(class {type} value);\n"
 implementations["member_class_setter"] = "void {classname}::{fname}(class {type} value) {{ m_obj->data.{name} = value; }}\n"
 
 # this is inline, don't need the declaration
-implementations["const_member_getter"] = "\tconst {type}& Const{classname}::{fname}() const {{ return m_obj->data.{name}; }}\n"
+implementations["const_member_getter"] =  "\t/// Access the {description}\n"
+implementations["const_member_getter"] += "\tconst {type}& Const{classname}::{fname}() const {{ return m_obj->data.{name}; }}\n"
 
 # OneToOneRelations
 #-----------------------------------
-declarations["one_rel_setter"] = "\tvoid {name}({namespace}::Const{type} value);\n"
+declarations["one_rel_setter"] =  "\t/// Set the {description}\n"
+declarations["one_rel_setter"] += "\tvoid {name}({namespace}::Const{type} value);\n"
 implementations["one_rel_setter"]  = "void {classname}::{name}({namespace}::Const{type} value) {{\n"
 implementations["one_rel_setter"] += "\tif (m_obj->m_{name} != nullptr) delete m_obj->m_{name};\n"
 implementations["one_rel_setter"] += "\tm_obj->m_{name} = new Const{type}(value);\n}}\n"
 
-declarations["one_rel_getter"] = "\tconst {namespace}::Const{type} {name}() const;\n"
+declarations["one_rel_getter"] =  "\t/// Access the {description}\n"
+declarations["one_rel_getter"] += "\tconst {namespace}::Const{type} {name}() const;\n"
 implementations["one_rel_getter"] = "\tconst {namespace}::Const{type} {classname}::{name}() const {{\n"
 implementations["one_rel_getter"] += "\t\tif (m_obj->m_{name} == nullptr) {{\n"
 implementations["one_rel_getter"] += "\t\t\treturn {namespace}::Const{type}(nullptr);\n"
 implementations["one_rel_getter"] += "\t\t}}\n"
 implementations["one_rel_getter"] += "\t\treturn {namespace}::Const{type}(*(m_obj->m_{name}));\n\t}}"
 # this is inline, don't need the declaration
-implementations["const_one_rel_getter"] = "\tconst {namespace}::Const{type} Const{classname}::{name}() const {{\n"
+implementations["const_one_rel_getter"] =  "\t/// Access the {description}\n"
+implementations["const_one_rel_getter"] += "\tconst {namespace}::Const{type} Const{classname}::{name}() const {{\n"
 implementations["const_one_rel_getter"] += "\t\tif (m_obj->m_{name} == nullptr) {{\n"
 implementations["const_one_rel_getter"] += "\t\t\treturn {namespace}::Const{type}(nullptr);\n"
 implementations["const_one_rel_getter"] += "\t\t}}\n"

--- a/templates/Collection.cc.template
+++ b/templates/Collection.cc.template
@@ -14,7 +14,7 @@ ${name}Collection::~${name}Collection() {
   clear();
   if (m_data != nullptr) delete m_data;
   ${destructorbody}
-};
+}
 
 const ${name} ${name}Collection::operator[](unsigned int index) const {
   return ${name}(m_entries[index]);

--- a/templates/ConstObject.h.template
+++ b/templates/ConstObject.h.template
@@ -4,9 +4,6 @@ $includes
 #include <vector>
 #include "podio/ObjectID.h"
 
-// $description
-// author: $author
-
 //forward declarations
 $forward_declarations
 
@@ -18,6 +15,11 @@ class ${name}Obj;
 class ${name};
 class ${name}Collection;
 class ${name}CollectionIterator;
+
+/** @class Const${name}
+ *  $description
+ *  @author: $author
+ */
 
 class Const${name} {
 

--- a/templates/Data.h.template
+++ b/templates/Data.h.template
@@ -1,12 +1,14 @@
 #ifndef ${name}DATA_H
 #define ${name}DATA_H
 
-// $description
-// author: $author
-
 $includes
 
 ${namespace_open}
+/** @class ${name}Data
+ *  $description
+ *  @author: $author
+ */
+
 class ${name}Data {
 public:
 $members

--- a/templates/Object.h.template
+++ b/templates/Object.h.template
@@ -4,9 +4,6 @@ $includes
 #include <vector>
 #include "podio/ObjectID.h"
 
-// $description
-// author: $author
-
 //forward declarations
 $forward_declarations
 
@@ -19,6 +16,10 @@ class ${name}Collection;
 class ${name}CollectionIterator;
 class Const${name};
 
+/** @class ${name}
+ *  $description
+ *  @author: $author
+ */
 class ${name} {
 
   friend ${name}Collection;

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -1,4 +1,10 @@
 ---
+options :
+  # should getters / setters be prefixed with get / set?
+  getSyntax: False
+  # should POD members be exposed with getters/setters in classes that have them as members?
+  exposePODMembers: True
+
 components :
   SimpleStruct:
     x : int

--- a/tests/datamodel/EventInfo.h
+++ b/tests/datamodel/EventInfo.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Event info
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -19,6 +16,10 @@ class EventInfoCollection;
 class EventInfoCollectionIterator;
 class ConstEventInfo;
 
+/** @class EventInfo
+ *  Event info
+ *  @author: B. Hegner
+ */
 class EventInfo {
 
   friend EventInfoCollection;
@@ -47,8 +48,10 @@ public:
 
 public:
 
+  /// Access the  event number
   const int& Number() const;
 
+  /// Set the  event number
   void Number(int value);
 
 

--- a/tests/datamodel/EventInfoConst.h
+++ b/tests/datamodel/EventInfoConst.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Event info
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -18,6 +15,11 @@ class EventInfoObj;
 class EventInfo;
 class EventInfoCollection;
 class EventInfoCollectionIterator;
+
+/** @class ConstEventInfo
+ *  Event info
+ *  @author: B. Hegner
+ */
 
 class ConstEventInfo {
 
@@ -45,6 +47,7 @@ public:
 
 public:
 
+  /// Access the  event number
   const int& Number() const;
 
 

--- a/tests/datamodel/EventInfoData.h
+++ b/tests/datamodel/EventInfoData.h
@@ -1,11 +1,13 @@
 #ifndef EventInfoDATA_H
 #define EventInfoDATA_H
 
-// Event info
-// author: B. Hegner
 
 
 
+/** @class EventInfoData
+ *  Event info
+ *  @author: B. Hegner
+ */
 
 class EventInfoData {
 public:

--- a/tests/datamodel/ExampleCluster.h
+++ b/tests/datamodel/ExampleCluster.h
@@ -7,9 +7,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Cluster
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -22,6 +19,10 @@ class ExampleClusterCollection;
 class ExampleClusterCollectionIterator;
 class ConstExampleCluster;
 
+/** @class ExampleCluster
+ *  Cluster
+ *  @author: B. Hegner
+ */
 class ExampleCluster {
 
   friend ExampleClusterCollection;
@@ -50,8 +51,10 @@ public:
 
 public:
 
+  /// Access the  cluster energy
   const double& energy() const;
 
+  /// Set the  cluster energy
   void energy(double value);
 
 

--- a/tests/datamodel/ExampleClusterConst.h
+++ b/tests/datamodel/ExampleClusterConst.h
@@ -7,9 +7,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Cluster
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -21,6 +18,11 @@ class ExampleClusterObj;
 class ExampleCluster;
 class ExampleClusterCollection;
 class ExampleClusterCollectionIterator;
+
+/** @class ConstExampleCluster
+ *  Cluster
+ *  @author: B. Hegner
+ */
 
 class ConstExampleCluster {
 
@@ -48,6 +50,7 @@ public:
 
 public:
 
+  /// Access the  cluster energy
   const double& energy() const;
 
   unsigned int Hits_size() const;

--- a/tests/datamodel/ExampleClusterData.h
+++ b/tests/datamodel/ExampleClusterData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleClusterDATA_H
 #define ExampleClusterDATA_H
 
-// Cluster
-// author: B. Hegner
 
 
 
+/** @class ExampleClusterData
+ *  Cluster
+ *  @author: B. Hegner
+ */
 
 class ExampleClusterData {
 public:

--- a/tests/datamodel/ExampleForCyclicDependency1.h
+++ b/tests/datamodel/ExampleForCyclicDependency1.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type for cyclic dependency
-// author: Benedikt Hegner
-
 //forward declarations
 class ExampleForCyclicDependency2;
 class ConstExampleForCyclicDependency2;
@@ -21,6 +18,10 @@ class ExampleForCyclicDependency1Collection;
 class ExampleForCyclicDependency1CollectionIterator;
 class ConstExampleForCyclicDependency1;
 
+/** @class ExampleForCyclicDependency1
+ *  Type for cyclic dependency
+ *  @author: Benedikt Hegner
+ */
 class ExampleForCyclicDependency1 {
 
   friend ExampleForCyclicDependency1Collection;
@@ -48,8 +49,10 @@ public:
 
 public:
 
+  /// Access the  a ref
   const ::ConstExampleForCyclicDependency2 ref() const;
 
+  /// Set the  a ref
   void ref(::ConstExampleForCyclicDependency2 value);
 
 

--- a/tests/datamodel/ExampleForCyclicDependency1Const.h
+++ b/tests/datamodel/ExampleForCyclicDependency1Const.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type for cyclic dependency
-// author: Benedikt Hegner
-
 //forward declarations
 class ExampleForCyclicDependency2;
 class ConstExampleForCyclicDependency2;
@@ -20,6 +17,11 @@ class ExampleForCyclicDependency1Obj;
 class ExampleForCyclicDependency1;
 class ExampleForCyclicDependency1Collection;
 class ExampleForCyclicDependency1CollectionIterator;
+
+/** @class ConstExampleForCyclicDependency1
+ *  Type for cyclic dependency
+ *  @author: Benedikt Hegner
+ */
 
 class ConstExampleForCyclicDependency1 {
 
@@ -46,6 +48,7 @@ public:
 
 public:
 
+  /// Access the  a ref
   const ::ConstExampleForCyclicDependency2 ref() const;
 
 

--- a/tests/datamodel/ExampleForCyclicDependency1Data.h
+++ b/tests/datamodel/ExampleForCyclicDependency1Data.h
@@ -1,11 +1,13 @@
 #ifndef ExampleForCyclicDependency1DATA_H
 #define ExampleForCyclicDependency1DATA_H
 
-// Type for cyclic dependency
-// author: Benedikt Hegner
 
 
 
+/** @class ExampleForCyclicDependency1Data
+ *  Type for cyclic dependency
+ *  @author: Benedikt Hegner
+ */
 
 class ExampleForCyclicDependency1Data {
 public:

--- a/tests/datamodel/ExampleForCyclicDependency2.h
+++ b/tests/datamodel/ExampleForCyclicDependency2.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type for cyclic dependency
-// author: Benedikt Hegner
-
 //forward declarations
 class ExampleForCyclicDependency1;
 class ConstExampleForCyclicDependency1;
@@ -21,6 +18,10 @@ class ExampleForCyclicDependency2Collection;
 class ExampleForCyclicDependency2CollectionIterator;
 class ConstExampleForCyclicDependency2;
 
+/** @class ExampleForCyclicDependency2
+ *  Type for cyclic dependency
+ *  @author: Benedikt Hegner
+ */
 class ExampleForCyclicDependency2 {
 
   friend ExampleForCyclicDependency2Collection;
@@ -48,8 +49,10 @@ public:
 
 public:
 
+  /// Access the  a ref
   const ::ConstExampleForCyclicDependency1 ref() const;
 
+  /// Set the  a ref
   void ref(::ConstExampleForCyclicDependency1 value);
 
 

--- a/tests/datamodel/ExampleForCyclicDependency2Const.h
+++ b/tests/datamodel/ExampleForCyclicDependency2Const.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type for cyclic dependency
-// author: Benedikt Hegner
-
 //forward declarations
 class ExampleForCyclicDependency1;
 class ConstExampleForCyclicDependency1;
@@ -20,6 +17,11 @@ class ExampleForCyclicDependency2Obj;
 class ExampleForCyclicDependency2;
 class ExampleForCyclicDependency2Collection;
 class ExampleForCyclicDependency2CollectionIterator;
+
+/** @class ConstExampleForCyclicDependency2
+ *  Type for cyclic dependency
+ *  @author: Benedikt Hegner
+ */
 
 class ConstExampleForCyclicDependency2 {
 
@@ -46,6 +48,7 @@ public:
 
 public:
 
+  /// Access the  a ref
   const ::ConstExampleForCyclicDependency1 ref() const;
 
 

--- a/tests/datamodel/ExampleForCyclicDependency2Data.h
+++ b/tests/datamodel/ExampleForCyclicDependency2Data.h
@@ -1,11 +1,13 @@
 #ifndef ExampleForCyclicDependency2DATA_H
 #define ExampleForCyclicDependency2DATA_H
 
-// Type for cyclic dependency
-// author: Benedikt Hegner
 
 
 
+/** @class ExampleForCyclicDependency2Data
+ *  Type for cyclic dependency
+ *  @author: Benedikt Hegner
+ */
 
 class ExampleForCyclicDependency2Data {
 public:

--- a/tests/datamodel/ExampleHit.h
+++ b/tests/datamodel/ExampleHit.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Example Hit
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -19,6 +16,10 @@ class ExampleHitCollection;
 class ExampleHitCollectionIterator;
 class ConstExampleHit;
 
+/** @class ExampleHit
+ *  Example Hit
+ *  @author: B. Hegner
+ */
 class ExampleHit {
 
   friend ExampleHitCollection;
@@ -47,17 +48,25 @@ public:
 
 public:
 
+  /// Access the  x-coordinate
   const double& x() const;
+  /// Access the  y-coordinate
   const double& y() const;
+  /// Access the  z-coordinate
   const double& z() const;
+  /// Access the  measured energy deposit
   const double& energy() const;
 
+  /// Set the  x-coordinate
   void x(double value);
 
+  /// Set the  y-coordinate
   void y(double value);
 
+  /// Set the  z-coordinate
   void z(double value);
 
+  /// Set the  measured energy deposit
   void energy(double value);
 
 

--- a/tests/datamodel/ExampleHitConst.h
+++ b/tests/datamodel/ExampleHitConst.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Example Hit
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -18,6 +15,11 @@ class ExampleHitObj;
 class ExampleHit;
 class ExampleHitCollection;
 class ExampleHitCollectionIterator;
+
+/** @class ConstExampleHit
+ *  Example Hit
+ *  @author: B. Hegner
+ */
 
 class ConstExampleHit {
 
@@ -45,9 +47,13 @@ public:
 
 public:
 
+  /// Access the  x-coordinate
   const double& x() const;
+  /// Access the  y-coordinate
   const double& y() const;
+  /// Access the  z-coordinate
   const double& z() const;
+  /// Access the  measured energy deposit
   const double& energy() const;
 
 

--- a/tests/datamodel/ExampleHitData.h
+++ b/tests/datamodel/ExampleHitData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleHitDATA_H
 #define ExampleHitDATA_H
 
-// Example Hit
-// author: B. Hegner
 
 
 
+/** @class ExampleHitData
+ *  Example Hit
+ *  @author: B. Hegner
+ */
 
 class ExampleHitData {
 public:

--- a/tests/datamodel/ExampleMC.h
+++ b/tests/datamodel/ExampleMC.h
@@ -7,9 +7,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Example MC-particle
-// author: F.Gaede
-
 //forward declarations
 
 
@@ -22,6 +19,10 @@ class ExampleMCCollection;
 class ExampleMCCollectionIterator;
 class ConstExampleMC;
 
+/** @class ExampleMC
+ *  Example MC-particle
+ *  @author: F.Gaede
+ */
 class ExampleMC {
 
   friend ExampleMCCollection;
@@ -50,11 +51,15 @@ public:
 
 public:
 
+  /// Access the  energy
   const double& energy() const;
+  /// Access the  PDG code
   const int& PDG() const;
 
+  /// Set the  energy
   void energy(double value);
 
+  /// Set the  PDG code
   void PDG(int value);
 
 

--- a/tests/datamodel/ExampleMCConst.h
+++ b/tests/datamodel/ExampleMCConst.h
@@ -7,9 +7,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Example MC-particle
-// author: F.Gaede
-
 //forward declarations
 
 
@@ -21,6 +18,11 @@ class ExampleMCObj;
 class ExampleMC;
 class ExampleMCCollection;
 class ExampleMCCollectionIterator;
+
+/** @class ConstExampleMC
+ *  Example MC-particle
+ *  @author: F.Gaede
+ */
 
 class ConstExampleMC {
 
@@ -48,7 +50,9 @@ public:
 
 public:
 
+  /// Access the  energy
   const double& energy() const;
+  /// Access the  PDG code
   const int& PDG() const;
 
   unsigned int parents_size() const;

--- a/tests/datamodel/ExampleMCData.h
+++ b/tests/datamodel/ExampleMCData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleMCDATA_H
 #define ExampleMCDATA_H
 
-// Example MC-particle
-// author: F.Gaede
 
 
 
+/** @class ExampleMCData
+ *  Example MC-particle
+ *  @author: F.Gaede
+ */
 
 class ExampleMCData {
 public:

--- a/tests/datamodel/ExampleReferencingType.h
+++ b/tests/datamodel/ExampleReferencingType.h
@@ -7,9 +7,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Referencing Type
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -22,6 +19,10 @@ class ExampleReferencingTypeCollection;
 class ExampleReferencingTypeCollectionIterator;
 class ConstExampleReferencingType;
 
+/** @class ExampleReferencingType
+ *  Referencing Type
+ *  @author: B. Hegner
+ */
 class ExampleReferencingType {
 
   friend ExampleReferencingTypeCollection;

--- a/tests/datamodel/ExampleReferencingTypeConst.h
+++ b/tests/datamodel/ExampleReferencingTypeConst.h
@@ -7,9 +7,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Referencing Type
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -21,6 +18,11 @@ class ExampleReferencingTypeObj;
 class ExampleReferencingType;
 class ExampleReferencingTypeCollection;
 class ExampleReferencingTypeCollectionIterator;
+
+/** @class ConstExampleReferencingType
+ *  Referencing Type
+ *  @author: B. Hegner
+ */
 
 class ConstExampleReferencingType {
 

--- a/tests/datamodel/ExampleReferencingTypeData.h
+++ b/tests/datamodel/ExampleReferencingTypeData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleReferencingTypeDATA_H
 #define ExampleReferencingTypeDATA_H
 
-// Referencing Type
-// author: B. Hegner
 
 
 
+/** @class ExampleReferencingTypeData
+ *  Referencing Type
+ *  @author: B. Hegner
+ */
 
 class ExampleReferencingTypeData {
 public:

--- a/tests/datamodel/ExampleWithARelation.h
+++ b/tests/datamodel/ExampleWithARelation.h
@@ -6,9 +6,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with namespace and namespaced relation
-// author: Joschka Lingemann
-
 //forward declarations
 namespace ex {
 class ExampleWithNamespace;
@@ -25,6 +22,10 @@ class ExampleWithARelationCollection;
 class ExampleWithARelationCollectionIterator;
 class ConstExampleWithARelation;
 
+/** @class ExampleWithARelation
+ *  Type with namespace and namespaced relation
+ *  @author: Joschka Lingemann
+ */
 class ExampleWithARelation {
 
   friend ExampleWithARelationCollection;
@@ -52,8 +53,10 @@ public:
 
 public:
 
+  /// Access the  a ref in a namespace
   const ex::ConstExampleWithNamespace ref() const;
 
+  /// Set the  a ref in a namespace
   void ref(ex::ConstExampleWithNamespace value);
 
   void addrefs(ex::ConstExampleWithNamespace);

--- a/tests/datamodel/ExampleWithARelationConst.h
+++ b/tests/datamodel/ExampleWithARelationConst.h
@@ -6,9 +6,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with namespace and namespaced relation
-// author: Joschka Lingemann
-
 //forward declarations
 namespace ex {
 class ExampleWithNamespace;
@@ -24,6 +21,11 @@ class ExampleWithARelationObj;
 class ExampleWithARelation;
 class ExampleWithARelationCollection;
 class ExampleWithARelationCollectionIterator;
+
+/** @class ConstExampleWithARelation
+ *  Type with namespace and namespaced relation
+ *  @author: Joschka Lingemann
+ */
 
 class ConstExampleWithARelation {
 
@@ -50,6 +52,7 @@ public:
 
 public:
 
+  /// Access the  a ref in a namespace
   const ex::ConstExampleWithNamespace ref() const;
 
   unsigned int refs_size() const;

--- a/tests/datamodel/ExampleWithARelationData.h
+++ b/tests/datamodel/ExampleWithARelationData.h
@@ -1,12 +1,14 @@
 #ifndef ExampleWithARelationDATA_H
 #define ExampleWithARelationDATA_H
 
-// Type with namespace and namespaced relation
-// author: Joschka Lingemann
-
 
 
 namespace ex {
+/** @class ExampleWithARelationData
+ *  Type with namespace and namespaced relation
+ *  @author: Joschka Lingemann
+ */
+
 class ExampleWithARelationData {
 public:
   unsigned int refs_begin;

--- a/tests/datamodel/ExampleWithComponent.h
+++ b/tests/datamodel/ExampleWithComponent.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with one component
-// author: Benedikt Hegner
-
 //forward declarations
 
 
@@ -20,6 +17,10 @@ class ExampleWithComponentCollection;
 class ExampleWithComponentCollectionIterator;
 class ConstExampleWithComponent;
 
+/** @class ExampleWithComponent
+ *  Type with one component
+ *  @author: Benedikt Hegner
+ */
 class ExampleWithComponent {
 
   friend ExampleWithComponentCollection;
@@ -48,10 +49,16 @@ public:
 
 public:
 
+  /// Access the  a component
   const NotSoSimpleStruct& component() const;
+  const SimpleStruct& data() const;
 
+  /// Get reference to the  a component
   NotSoSimpleStruct& component();
+  /// Set the  a component
   void component(class NotSoSimpleStruct value);
+  SimpleStruct& data();
+  void data(class SimpleStruct value);
 
 
 

--- a/tests/datamodel/ExampleWithComponentConst.h
+++ b/tests/datamodel/ExampleWithComponentConst.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with one component
-// author: Benedikt Hegner
-
 //forward declarations
 
 
@@ -19,6 +16,11 @@ class ExampleWithComponentObj;
 class ExampleWithComponent;
 class ExampleWithComponentCollection;
 class ExampleWithComponentCollectionIterator;
+
+/** @class ConstExampleWithComponent
+ *  Type with one component
+ *  @author: Benedikt Hegner
+ */
 
 class ConstExampleWithComponent {
 
@@ -46,7 +48,9 @@ public:
 
 public:
 
+  /// Access the  a component
   const NotSoSimpleStruct& component() const;
+  const SimpleStruct& data() const;
 
 
 

--- a/tests/datamodel/ExampleWithComponentData.h
+++ b/tests/datamodel/ExampleWithComponentData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleWithComponentDATA_H
 #define ExampleWithComponentDATA_H
 
-// Type with one component
-// author: Benedikt Hegner
-
 #include "NotSoSimpleStruct.h"
 
+
+/** @class ExampleWithComponentData
+ *  Type with one component
+ *  @author: Benedikt Hegner
+ */
 
 class ExampleWithComponentData {
 public:

--- a/tests/datamodel/ExampleWithNamespace.h
+++ b/tests/datamodel/ExampleWithNamespace.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with namespace and namespaced member
-// author: Joschka Lingemann
-
 //forward declarations
 
 
@@ -20,6 +17,10 @@ class ExampleWithNamespaceCollection;
 class ExampleWithNamespaceCollectionIterator;
 class ConstExampleWithNamespace;
 
+/** @class ExampleWithNamespace
+ *  Type with namespace and namespaced member
+ *  @author: Joschka Lingemann
+ */
 class ExampleWithNamespace {
 
   friend ExampleWithNamespaceCollection;
@@ -48,10 +49,19 @@ public:
 
 public:
 
+  /// Access the  a component
   const ex2::NamespaceStruct& data() const;
+  const int& x() const;
+  const int& y() const;
 
+  /// Get reference to the  a component
   ex2::NamespaceStruct& data();
+  /// Set the  a component
   void data(class ex2::NamespaceStruct value);
+  void x(int value);
+
+  void y(int value);
+
 
 
 

--- a/tests/datamodel/ExampleWithNamespaceConst.h
+++ b/tests/datamodel/ExampleWithNamespaceConst.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with namespace and namespaced member
-// author: Joschka Lingemann
-
 //forward declarations
 
 
@@ -19,6 +16,11 @@ class ExampleWithNamespaceObj;
 class ExampleWithNamespace;
 class ExampleWithNamespaceCollection;
 class ExampleWithNamespaceCollectionIterator;
+
+/** @class ConstExampleWithNamespace
+ *  Type with namespace and namespaced member
+ *  @author: Joschka Lingemann
+ */
 
 class ConstExampleWithNamespace {
 
@@ -46,7 +48,10 @@ public:
 
 public:
 
+  /// Access the  a component
   const ex2::NamespaceStruct& data() const;
+  const int& x() const;
+  const int& y() const;
 
 
 

--- a/tests/datamodel/ExampleWithNamespaceData.h
+++ b/tests/datamodel/ExampleWithNamespaceData.h
@@ -1,12 +1,14 @@
 #ifndef ExampleWithNamespaceDATA_H
 #define ExampleWithNamespaceDATA_H
 
-// Type with namespace and namespaced member
-// author: Joschka Lingemann
-
 #include "NamespaceStruct.h"
 
 namespace ex {
+/** @class ExampleWithNamespaceData
+ *  Type with namespace and namespaced member
+ *  @author: Joschka Lingemann
+ */
+
 class ExampleWithNamespaceData {
 public:
   ex2::NamespaceStruct data;  ///< a component

--- a/tests/datamodel/ExampleWithOneRelation.h
+++ b/tests/datamodel/ExampleWithOneRelation.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with one relation member
-// author: Benedikt Hegner
-
 //forward declarations
 class ExampleCluster;
 class ConstExampleCluster;
@@ -21,6 +18,10 @@ class ExampleWithOneRelationCollection;
 class ExampleWithOneRelationCollectionIterator;
 class ConstExampleWithOneRelation;
 
+/** @class ExampleWithOneRelation
+ *  Type with one relation member
+ *  @author: Benedikt Hegner
+ */
 class ExampleWithOneRelation {
 
   friend ExampleWithOneRelationCollection;
@@ -48,8 +49,10 @@ public:
 
 public:
 
+  /// Access the  a particular cluster
   const ::ConstExampleCluster cluster() const;
 
+  /// Set the  a particular cluster
   void cluster(::ConstExampleCluster value);
 
 

--- a/tests/datamodel/ExampleWithOneRelationConst.h
+++ b/tests/datamodel/ExampleWithOneRelationConst.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with one relation member
-// author: Benedikt Hegner
-
 //forward declarations
 class ExampleCluster;
 class ConstExampleCluster;
@@ -20,6 +17,11 @@ class ExampleWithOneRelationObj;
 class ExampleWithOneRelation;
 class ExampleWithOneRelationCollection;
 class ExampleWithOneRelationCollectionIterator;
+
+/** @class ConstExampleWithOneRelation
+ *  Type with one relation member
+ *  @author: Benedikt Hegner
+ */
 
 class ConstExampleWithOneRelation {
 
@@ -46,6 +48,7 @@ public:
 
 public:
 
+  /// Access the  a particular cluster
   const ::ConstExampleCluster cluster() const;
 
 

--- a/tests/datamodel/ExampleWithOneRelationData.h
+++ b/tests/datamodel/ExampleWithOneRelationData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleWithOneRelationDATA_H
 #define ExampleWithOneRelationDATA_H
 
-// Type with one relation member
-// author: Benedikt Hegner
 
 
 
+/** @class ExampleWithOneRelationData
+ *  Type with one relation member
+ *  @author: Benedikt Hegner
+ */
 
 class ExampleWithOneRelationData {
 public:

--- a/tests/datamodel/ExampleWithString.h
+++ b/tests/datamodel/ExampleWithString.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with a string
-// author: Benedikt Hegner
-
 //forward declarations
 
 
@@ -20,6 +17,10 @@ class ExampleWithStringCollection;
 class ExampleWithStringCollectionIterator;
 class ConstExampleWithString;
 
+/** @class ExampleWithString
+ *  Type with a string
+ *  @author: Benedikt Hegner
+ */
 class ExampleWithString {
 
   friend ExampleWithStringCollection;
@@ -48,8 +49,10 @@ public:
 
 public:
 
+  /// Access the  the string
   const std::string& theString() const;
 
+  /// Set the  the string
   void theString(std::string value);
 
 

--- a/tests/datamodel/ExampleWithStringConst.h
+++ b/tests/datamodel/ExampleWithStringConst.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with a string
-// author: Benedikt Hegner
-
 //forward declarations
 
 
@@ -19,6 +16,11 @@ class ExampleWithStringObj;
 class ExampleWithString;
 class ExampleWithStringCollection;
 class ExampleWithStringCollectionIterator;
+
+/** @class ConstExampleWithString
+ *  Type with a string
+ *  @author: Benedikt Hegner
+ */
 
 class ConstExampleWithString {
 
@@ -46,6 +48,7 @@ public:
 
 public:
 
+  /// Access the  the string
   const std::string& theString() const;
 
 

--- a/tests/datamodel/ExampleWithStringData.h
+++ b/tests/datamodel/ExampleWithStringData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleWithStringDATA_H
 #define ExampleWithStringDATA_H
 
-// Type with a string
-// author: Benedikt Hegner
-
 #include <string>
 
+
+/** @class ExampleWithStringData
+ *  Type with a string
+ *  @author: Benedikt Hegner
+ */
 
 class ExampleWithStringData {
 public:

--- a/tests/datamodel/ExampleWithVectorMember.h
+++ b/tests/datamodel/ExampleWithVectorMember.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with a vector member
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -20,6 +17,10 @@ class ExampleWithVectorMemberCollection;
 class ExampleWithVectorMemberCollectionIterator;
 class ConstExampleWithVectorMember;
 
+/** @class ExampleWithVectorMember
+ *  Type with a vector member
+ *  @author: B. Hegner
+ */
 class ExampleWithVectorMember {
 
   friend ExampleWithVectorMemberCollection;

--- a/tests/datamodel/ExampleWithVectorMemberConst.h
+++ b/tests/datamodel/ExampleWithVectorMemberConst.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with a vector member
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -19,6 +16,11 @@ class ExampleWithVectorMemberObj;
 class ExampleWithVectorMember;
 class ExampleWithVectorMemberCollection;
 class ExampleWithVectorMemberCollectionIterator;
+
+/** @class ConstExampleWithVectorMember
+ *  Type with a vector member
+ *  @author: B. Hegner
+ */
 
 class ConstExampleWithVectorMember {
 

--- a/tests/datamodel/ExampleWithVectorMemberData.h
+++ b/tests/datamodel/ExampleWithVectorMemberData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleWithVectorMemberDATA_H
 #define ExampleWithVectorMemberDATA_H
 
-// Type with a vector member
-// author: B. Hegner
 
 
 
+/** @class ExampleWithVectorMemberData
+ *  Type with a vector member
+ *  @author: B. Hegner
+ */
 
 class ExampleWithVectorMemberData {
 public:

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -53,12 +53,12 @@ void processEvent(podio::EventStore& store, bool verboser) {
     for( auto p : mcps ){
       std::cout << " particle " << p.getObjectID().index << " daughters: " ;
       for(auto it = p.daughters_begin(), end = p.daughters_end() ; it!=end ; ++it ){
-	int dIndex = it->getObjectID().index ;
-	std::cout << " " << dIndex ;
+  int dIndex = it->getObjectID().index ;
+  std::cout << " " << dIndex ;
       } 
       std::cout << "  and parents: " ;
       for(auto it = p.parents_begin(), end = p.parents_end() ; it!=end ; ++it ){
-	std::cout << " " << it->getObjectID().index ;
+  std::cout << " " << it->getObjectID().index ;
       }
       std::cout << std::endl ;
     }
@@ -103,7 +103,7 @@ void processEvent(podio::EventStore& store, bool verboser) {
   auto& nmspaces = store.get<ex::ExampleWithARelationCollection>("WithNamespaceRelation");
   if (nmspaces.isValid()) {
     auto nmsp = nmspaces[0];
-    int b = nmsp.ref().data().x + nmsp.ref().data().y;
+    int b = nmsp.ref().x() + nmsp.ref().data().y;
   }
 }
 

--- a/tests/src/EventInfoConst.cc
+++ b/tests/src/EventInfoConst.cc
@@ -42,6 +42,7 @@ ConstEventInfo::~ConstEventInfo(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  event number
   const int& ConstEventInfo::Number() const { return m_obj->data.Number; }
 
 

--- a/tests/src/ExampleClusterConst.cc
+++ b/tests/src/ExampleClusterConst.cc
@@ -42,6 +42,7 @@ ConstExampleCluster::~ConstExampleCluster(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  cluster energy
   const double& ConstExampleCluster::energy() const { return m_obj->data.energy; }
 
 std::vector<::ConstExampleHit>::const_iterator ConstExampleCluster::Hits_begin() const {

--- a/tests/src/ExampleForCyclicDependency1Const.cc
+++ b/tests/src/ExampleForCyclicDependency1Const.cc
@@ -39,6 +39,7 @@ ConstExampleForCyclicDependency1::~ConstExampleForCyclicDependency1(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  a ref
   const ::ConstExampleForCyclicDependency2 ConstExampleForCyclicDependency1::ref() const {
     if (m_obj->m_ref == nullptr) {
       return ::ConstExampleForCyclicDependency2(nullptr);

--- a/tests/src/ExampleForCyclicDependency2Const.cc
+++ b/tests/src/ExampleForCyclicDependency2Const.cc
@@ -39,6 +39,7 @@ ConstExampleForCyclicDependency2::~ConstExampleForCyclicDependency2(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  a ref
   const ::ConstExampleForCyclicDependency1 ConstExampleForCyclicDependency2::ref() const {
     if (m_obj->m_ref == nullptr) {
       return ::ConstExampleForCyclicDependency1(nullptr);

--- a/tests/src/ExampleHitConst.cc
+++ b/tests/src/ExampleHitConst.cc
@@ -42,9 +42,13 @@ ConstExampleHit::~ConstExampleHit(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  x-coordinate
   const double& ConstExampleHit::x() const { return m_obj->data.x; }
+  /// Access the  y-coordinate
   const double& ConstExampleHit::y() const { return m_obj->data.y; }
+  /// Access the  z-coordinate
   const double& ConstExampleHit::z() const { return m_obj->data.z; }
+  /// Access the  measured energy deposit
   const double& ConstExampleHit::energy() const { return m_obj->data.energy; }
 
 

--- a/tests/src/ExampleMCConst.cc
+++ b/tests/src/ExampleMCConst.cc
@@ -42,7 +42,9 @@ ConstExampleMC::~ConstExampleMC(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  energy
   const double& ConstExampleMC::energy() const { return m_obj->data.energy; }
+  /// Access the  PDG code
   const int& ConstExampleMC::PDG() const { return m_obj->data.PDG; }
 
 std::vector<::ConstExampleMC>::const_iterator ConstExampleMC::parents_begin() const {

--- a/tests/src/ExampleWithARelationConst.cc
+++ b/tests/src/ExampleWithARelationConst.cc
@@ -39,6 +39,7 @@ ConstExampleWithARelation::~ConstExampleWithARelation(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  a ref in a namespace
   const ex::ConstExampleWithNamespace ConstExampleWithARelation::ref() const {
     if (m_obj->m_ref == nullptr) {
       return ex::ConstExampleWithNamespace(nullptr);

--- a/tests/src/ExampleWithComponent.cc
+++ b/tests/src/ExampleWithComponent.cc
@@ -45,9 +45,12 @@ ExampleWithComponent::~ExampleWithComponent(){
 ExampleWithComponent::operator ConstExampleWithComponent() const {return ConstExampleWithComponent(m_obj);}
 
   const NotSoSimpleStruct& ExampleWithComponent::component() const { return m_obj->data.component; }
+const SimpleStruct& ExampleWithComponent::data() const { return m_obj->data.component.data; }
 
   NotSoSimpleStruct& ExampleWithComponent::component() { return m_obj->data.component; }
 void ExampleWithComponent::component(class NotSoSimpleStruct value) { m_obj->data.component = value; }
+SimpleStruct& ExampleWithComponent::data() { return m_obj->data.component.data; }
+void ExampleWithComponent::data(class SimpleStruct value) { m_obj->data.component.data = value; }
 
 
 

--- a/tests/src/ExampleWithComponentConst.cc
+++ b/tests/src/ExampleWithComponentConst.cc
@@ -42,6 +42,8 @@ ConstExampleWithComponent::~ConstExampleWithComponent(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  const SimpleStruct& ConstExampleWithComponent::data() const { return m_obj->data.component.data; }
+  /// Access the  a component
   const NotSoSimpleStruct& ConstExampleWithComponent::component() const { return m_obj->data.component; }
 
 

--- a/tests/src/ExampleWithNamespace.cc
+++ b/tests/src/ExampleWithNamespace.cc
@@ -45,9 +45,13 @@ ExampleWithNamespace::~ExampleWithNamespace(){
 ExampleWithNamespace::operator ConstExampleWithNamespace() const {return ConstExampleWithNamespace(m_obj);}
 
   const ex2::NamespaceStruct& ExampleWithNamespace::data() const { return m_obj->data.data; }
+const int& ExampleWithNamespace::x() const { return m_obj->data.data.x; }
+const int& ExampleWithNamespace::y() const { return m_obj->data.data.y; }
 
   ex2::NamespaceStruct& ExampleWithNamespace::data() { return m_obj->data.data; }
 void ExampleWithNamespace::data(class ex2::NamespaceStruct value) { m_obj->data.data = value; }
+void ExampleWithNamespace::x(int value){ m_obj->data.data.x = value; }
+void ExampleWithNamespace::y(int value){ m_obj->data.data.y = value; }
 
 
 

--- a/tests/src/ExampleWithNamespaceConst.cc
+++ b/tests/src/ExampleWithNamespaceConst.cc
@@ -42,6 +42,9 @@ ConstExampleWithNamespace::~ConstExampleWithNamespace(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  const int& ConstExampleWithNamespace::x() const { return m_obj->data.data.x; }
+  const int& ConstExampleWithNamespace::y() const { return m_obj->data.data.y; }
+  /// Access the  a component
   const ex2::NamespaceStruct& ConstExampleWithNamespace::data() const { return m_obj->data.data; }
 
 

--- a/tests/src/ExampleWithOneRelationConst.cc
+++ b/tests/src/ExampleWithOneRelationConst.cc
@@ -39,6 +39,7 @@ ConstExampleWithOneRelation::~ConstExampleWithOneRelation(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  a particular cluster
   const ::ConstExampleCluster ConstExampleWithOneRelation::cluster() const {
     if (m_obj->m_cluster == nullptr) {
       return ::ConstExampleCluster(nullptr);

--- a/tests/src/ExampleWithStringConst.cc
+++ b/tests/src/ExampleWithStringConst.cc
@@ -42,6 +42,7 @@ ConstExampleWithString::~ConstExampleWithString(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  the string
   const std::string& ConstExampleWithString::theString() const { return m_obj->data.theString; }
 
 

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -119,20 +119,20 @@ int main(){
     for( unsigned j=0,N=mcps.size();j<N;++j){
       p = mcps[j] ;
       for(auto it = p.daughters_begin(), end = p.daughters_end() ; it!=end ; ++it ){
-	int dIndex = it->getObjectID().index ;
-	d = mcps[ dIndex ] ;
-	d.addparents( p ) ;
+  int dIndex = it->getObjectID().index ;
+  d = mcps[ dIndex ] ;
+  d.addparents( p ) ;
       }
     }
     //-------- print relations for debugging:
     for( auto p : mcps ){
       std::cout << " particle " << p.getObjectID().index << " has daughters: " ;
       for(auto it = p.daughters_begin(), end = p.daughters_end() ; it!=end ; ++it ){
-	std::cout << " " << it->getObjectID().index ;
+  std::cout << " " << it->getObjectID().index ;
       }
       std::cout << "  and parents: " ;
       for(auto it = p.parents_begin(), end = p.parents_end() ; it!=end ; ++it ){
-	std::cout << " " << it->getObjectID().index ;
+  std::cout << " " << it->getObjectID().index ;
       }
       std::cout << std::endl ;
     }
@@ -190,7 +190,7 @@ int main(){
 
 
     auto namesp = ex::ExampleWithNamespace();
-    namesp.data().x = 1;
+    namesp.x(1);
     namesp.data().y = i;
     namesps.push_back(namesp);
 


### PR DESCRIPTION
- If a class owns a component, setters and getters will now be generated for the members of those components
  - This can be switched off with an option
  - We currently don't check if there are name-clashes

- Added options to yaml descriptions, so far we have:
  - Switch between "get" and "set" prefixes (previously via command-line, I thought it would be useful ti have it be persistant for a given datamodel)
  - Switch for new component

- Improve generated comments:
  - Some were not doxygen-style comments (class descriptions)
  - The object classes now have the same documentation string as the data objects for the corresponding getters / setters