### PR TITLE
Fixes for relations and extending doxygen comments

### DIFF
--- a/doc/advanced_topics.md
+++ b/doc/advanced_topics.md
@@ -4,29 +4,7 @@
 ## Persistency
 
 The library is build such that it can support multiple storage backends. However, the tested storage system being used is ROOT.
-
-## Thread-safety
-
-PODIO was written with thread-safety in mind and avoids the usage of globals and statics. However, a few assumptions about user code and use-patterns were made. The following lists the caveats of the library when it comes to parallelization.
-
-### Setting user data
-
-The non-const variants of the user classes are in no way protected for concurrent update operations. However, if only dealing with the const-variants it is guaranteed that no internal state or cache prevents concurrent operations.
-
-### Serialization
-During the calls of `prepareForWriting` and `prepareAfterReading` on collections other operations like object creation or addition will lead to an inconsistent state.
-
-### Not-thread-safe components
-The example event store provided with PODIO is as of writing not thread-safe. Neither is the chosen serialization.
-
-
-## Implementing a transient Event Class
-
-PODIO contains one example `podio::EventStore` class. To implement your own transient event store, the only requirement is to set the collectionID of each collection to a unique ID on creation.
-
-## Implementing a persistency layer on top of PODIO
-
-PODIO contains one example persistency implementation, based on ROOT. However, it is possible to implement other serialization solution on top of PODIO.
+The following explains the requirements for a user-provided storage back-end.
 
 ### Writing Back-End
 
@@ -66,6 +44,23 @@ If not taking advantage of this implementation, the data reader or the event sto
     
 The strong assumption here is that all references are being followed up directly and no later on-demand reading is done. 
 
-### Necessary reflection information
+## Thread-safety
 
-To be written
+PODIO was written with thread-safety in mind and avoids the usage of globals and statics. 
+However, a few assumptions about user code and use-patterns were made. 
+The following lists the caveats of the library when it comes to parallelization.
+
+### Changing user data
+
+As explained in the section about mutability of data, thread-safety is only guaranteed if data are considered read-only after creation.
+
+### Serialization
+During the calls of `prepareForWriting` and `prepareAfterReading` on collections other operations like object creation or addition will lead to an inconsistent state.
+
+### Not-thread-safe components
+The example event store provided with PODIO is as of writing not thread-safe. Neither is the chosen serialization.
+
+## Implementing a transient Event Class
+
+PODIO contains one example `podio::EventStore` class. 
+To implement your own transient event store, the only requirement is to set the collectionID of each collection to a unique ID on creation.

--- a/doc/datamodel_syntax.md
+++ b/doc/datamodel_syntax.md
@@ -1,9 +1,27 @@
-# PODIO class definition syntax
+# Data Models and Data Model Definitions
 
-PODIO uses a user-written data model definition file
+To describe a data model PODIO provides a data model definition syntax.
+This is to ease the creation of optimised data formats, which may take advantage of a so-called `struct-of-array` data layout.
+From the user-provided data model description PODIO creates all the files necessary to use this data model.
+
+## Basic Concepts and Supported Features
+PODIO encourages the usage of composition, rather than inheritance.
+One of the reasons for doing so is the focus on efficiency friendly `plain-old-data`. 
+For this reason, PODIO does not support inheritance within the defined data model. 
+Instead, users can combine multiple `components` to build a to be used `datatype`.
+
+To allow the datatypes to be real PODs, the data stored within the data model are constrained to be
+POD-compatible data. Those are 
+
+ 1. basic types like int, double, etc
+ 1. components built up from basic types or other components
+ 1. Fixed sized arrays of those types
+ 
+In addition, PODIO supports the storage of one-to-one and one-to-many relations between objects.
+In the following the syntax for defining a given data model is explained. 
+A later section contains more details about the code being created from this.
 
 ## Definition of custom components
-
 A component is just a flat struct containing data. it can be defined via:
 
     components:
@@ -14,10 +32,9 @@ A component is just a flat struct containing data. it can be defined via:
         z : float
         a : AnotherComponent
 
-The purpose of components is to support the patter of composition rather than inheritance when building higher level data classes. Components can only contain simple data types and other components. 
-
 ## Definition of custom data classes
-This package allows the definition of data types using a simple syntax. This is to ease the creation of optimised data formats. Here an excerpt from "datamodel.yaml" for a simple class, just containing one member of the type `int`.
+Here an excerpt from "datamodel.yaml" for a simple class, just containing one member of the type `int`.
+
 
     datatypes :
       EventInfo :

--- a/doc/design.md
+++ b/doc/design.md
@@ -8,7 +8,8 @@ The driving considerations for the PODIO design are:
   1. The user does not do any explicit memory management
   1. Classes are generated using a higher-level abstraction and code generators
 
-The following sections give some more technical details and explanations for the design choices. More concrete implementation details can be found in the doxygen documentation.
+The following sections give some more technical details and explanations for the design choices. 
+More concrete implementation details can be found in the doxygen documentation.
 
 ## Layout of Objects
 The data model is based on four different kind of objects and layers, namely
@@ -46,16 +47,11 @@ The collections created serve three purposes:
 
 As an end-user oriented library, PODIO provides only a limited support for struct-of-arrays (SoA) memory layouts. In the vision, that the data used for heavy calculations is best copied locally, the library provides convenience methods for extracting the necessary information from the collections. More details can be found in the examples section of this document.
 
-### References between objects
+## Handling mutability
 
-The existence of relations between objects has been mentioned several times. 
+Depending on the policy of the client of PODIO, data collections may be read-only after creation, or may be altered still.
+While the base assumption of PODIO is that once-created collections are immutable once leaving the scope of its creator, 
+it still allows for explicit `unfreezing` collections afterwards. 
+This feature has to handled with care, as it heavily impacts thread-safety.
 
-#### Transient representation
-
-TODO
-
-## Handling const-correcteness
-
-As a peculiarity, PODIO provides dedicated const and non-const classes, instead of fully trusting the C++ `const` keyword. This is done for two reasons - to avoid accidental drop of the const-keyword on user side. And to hide the non-const methods in Python. A case for accidental dropping of the `const` keyword in C++ are implicit copies when using the auto keyword. 
-  
  

--- a/doc/doc.md
+++ b/doc/doc.md
@@ -6,9 +6,9 @@ At the same time it provides the necessary high-level functionality to the physi
 
 To support the usage of modern software technologies, PODIO was written with concurrency in mind and gives basic support for vectorization technologies.
 
-This document describes first how to define and create your own data model, then how to use the created data.
+This document describes first how to define and create a specific data model, then how to use the created data. Afterwards it will explain the overall design and a few of the technical details of the implementation. 
 
-Afterwards it will explain the overall design and a few of the technical details of the implementation. 
+Many of the design choices are inspired by previous experience of the [LCIO package](http://lcio.desy.de/) used for the studies of the international linear collider, and the [Gaudi Object Description](http://lhcb-comp.web.cern.ch/lhcb-comp/Frameworks/DataDictionary/Documents/GaudiObjDesc_docu.pdf) applied in the LHCb collaboration at the LHC. 
 
 # Quick-start
 

--- a/doc/doc_title.md
+++ b/doc/doc_title.md
@@ -5,12 +5,18 @@
 \vspace*{2.5cm}
 
 \huge
-PODIO - the POD I/O Library
+PODIO - the POD I/O Library\\
+Design Document v1.0
 
-\vspace{1.5cm}
+\vspace{0.5cm}
 
 \normalsize
-Benedikt Hegner (CERN)
+30.6.2016
+
+\vspace{1cm}
+
+Benedikt Hegner (CERN)\\
+Frank Gaede (DESY)
 
 \end{center}
 \end{titlepage}

--- a/include/podio/CollectionIDTable.h
+++ b/include/podio/CollectionIDTable.h
@@ -28,7 +28,10 @@ namespace podio {
     const std::string name(int collectionID) const;
 
     /// Check if collection name is known
-    bool present(const std::string& name) const; 
+    bool present(const std::string& name) const;
+
+    /// return registered names
+    const std::vector<std::string>& names() const { return m_names; };
 
     /// register new name to the table
     /// returns assigned collection ID

--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -64,7 +64,9 @@ namespace podio {
     /// set the reader
     void setReader(IReader* reader);
 
-    CollectionIDTable* getCollectionIDTable(){return m_table;};
+    CollectionIDTable* getCollectionIDTable() const {return m_table;};
+
+    virtual bool isValid() const final;
 
   private:
 

--- a/include/podio/IReader.h
+++ b/include/podio/IReader.h
@@ -28,6 +28,8 @@ class IReader {
     /// Get CollectionIDTable of read-in data
     virtual CollectionIDTable* getCollectionIDTable() = 0;
     //TODO: decide on smart-pointers for passing of objects
+    /// Check if reader is valid
+    virtual bool isValid() const = 0;
 };
 
 } // namespace

--- a/include/podio/PythonEventStore.h
+++ b/include/podio/PythonEventStore.h
@@ -24,6 +24,12 @@ public:
   /// get number of entries in the tree
   unsigned getEntries() const;
 
+  bool isValid() const {return m_reader.isValid();}
+  void close() {m_reader.closeFile();}
+
+  /// list available collections
+  const std::vector<std::string>& getCollectionNames() const;
+
  private:
   podio::ROOTReader m_reader;
   podio::EventStore m_store;

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -36,7 +36,7 @@ class ROOTReader : public IReader {
     ROOTReader() : m_eventNumber(0) {}
     ~ROOTReader();
     void openFile(const std::string& filename);
-    void closeFile(){};
+    void closeFile();
 
     /// Read all collections requested
     void readEvent();
@@ -56,6 +56,9 @@ class ROOTReader : public IReader {
 
     /// Preparing to read a given event
     void goToEvent(unsigned evnum);
+
+    /// Check if TFile is valid
+    virtual bool isValid() const;
 
   private:
 

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -601,6 +601,7 @@ class ClassGenerator(object):
       forward_declarations = ""
       forward_declarations_namespace = {"":[]}
       initialize_relations = ""
+      set_relations = ""
       deepcopy_relations = ""
       delete_relations = ""
       delete_singlerelations = ""
@@ -633,8 +634,10 @@ class ClassGenerator(object):
           if klass != classname:
             forward_declarations_namespace[mnamespace] += ['class Const%s;\n' %(klassname)]
             includes_cc += '#include "%sConst.h"\n' %(klassname)
-            initialize_relations += ",m_%s(nullptr)\n" %(name)
-            deepcopy_relations += ", m_%s(new %s(*(other.m_%s)))" % (name, klassWithQualifier, name)
+            initialize_relations += ", m_%s(nullptr)\n" %(name)
+            # for deep copy initialise as nullptr and set in copy ctor body if copied object has non-trivial relation
+            deepcopy_relations += ", m_%s(nullptr)" % (name)
+            set_relations += implementations["set_relations"].format(name=name, klass=klassWithQualifier)
           delete_singlerelations+="\t\tif (m_%s != nullptr) delete m_%s;\n" % (name, name)
 
       for nsp in forward_declarations_namespace.iterkeys():
@@ -686,7 +689,8 @@ class ClassGenerator(object):
                         "delete_relations" : delete_relations,
                         "delete_singlerelations" : delete_singlerelations,
                         "namespace_open" : namespace_open,
-                        "namespace_close" : namespace_close
+                        "namespace_close" : namespace_close,
+                        "set_deepcopy_relations": set_relations
       }
       self.fill_templates("Obj",substitutions)
       self.created_classes.append(classname+"Obj")

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -59,7 +59,7 @@ class ClassGenerator(object):
             self.create_class(name, components)
             self.create_collection(name, components)
             self.create_obj(name, components)
-            self.create_PrintInfo(name, components)
+            # self.create_PrintInfo(name, components)
 
     def print_report(self):
         if self.verbose:
@@ -69,9 +69,13 @@ class ClassGenerator(object):
                              len(self.created_classes),
                              self.install_dir
                              )
-        for i, line in enumerate(figure):
-            print
-            print line + text.splitlines()[i],
+        cntr = 0
+        print
+        for figline, summaryline in zip(figure, text.splitlines()):
+            cntr += 1
+            print figline + summaryline
+        for i in xrange(cntr, len(figure)):
+            print figure[i]
         print "     'Homage to the Square' - Josef Albers"
         print
 

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -613,10 +613,16 @@ class ClassGenerator(object):
         klass = item["type"]
         klassname = klass
         mnamespace = ""
-        if "::" in klass:
-          mnamespace, klassname = klass.split("::")
-          if mnamespace not in forward_declarations_namespace.keys():
-            forward_declarations_namespace[mnamespace] = []
+        if klass not in self.buildin_types:
+          if "::" in klass:
+            mnamespace, klassname = klass.split("::")
+            klassWithQualifier = "::"+mnamespace+"::Const"+klassname
+            if mnamespace not in forward_declarations_namespace.keys():
+              forward_declarations_namespace[mnamespace] = []
+          else:
+            klassWithQualifier = "Const"+klass
+        else:
+          klassWithQualifier = klass
 
         if mnamespace != "":
           relations+= "  ::%s::Const%s* m_%s;\n" %(mnamespace, klassname, name)
@@ -628,6 +634,7 @@ class ClassGenerator(object):
             forward_declarations_namespace[mnamespace] += ['class Const%s;\n' %(klassname)]
             includes_cc += '#include "%sConst.h"\n' %(klassname)
             initialize_relations += ",m_%s(nullptr)\n" %(name)
+            deepcopy_relations += ", m_%s(new %s(*(other.m_%s)))" % (name, klassWithQualifier, name)
           delete_singlerelations+="\t\tif (m_%s != nullptr) delete m_%s;\n" % (name, name)
 
       for nsp in forward_declarations_namespace.iterkeys():

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -24,22 +24,24 @@ _text_ = """
 class ClassGenerator(object):
 
     def __init__(self, yamlfile, install_dir, package_name,
-                 verbose=True, getSyntax=False):
+                 verbose=True):
 
         self.yamlfile = yamlfile
         self.install_dir = install_dir
         self.package_name = package_name
         self.template_dir = os.path.join(thisdir, "../templates")
         self.verbose = verbose
-        self.getSyntax = getSyntax
         self.buildin_types = ClassDefinitionValidator.buildin_types
         self.created_classes = []
         self.requested_classes = []
         self.reader = PodioConfigReader(yamlfile)
         self.warnings = []
+        self.component_members = {}
 
     def process(self):
         self.reader.read()
+        self.getSyntax = self.reader.options["getSyntax"]
+        self.expose_pod_members = self.reader.options["exposePODMembers"]
         self.process_components(self.reader.components)
         self.process_datatypes(self.reader.datatypes)
         self.create_selection_xml()
@@ -256,22 +258,44 @@ class ClassGenerator(object):
       for member in definition["Members"]:
         name = member["name"]
         klass = member["type"]
+        desc = member["description"]
         gname,sname = name,name
         if( self.getSyntax ):
           gname = "get" + name[:1].upper() + name[1:]
           sname = "set" + name[:1].upper() + name[1:]
-        getter_declarations += declarations["member_getter"].format(type=klass, name=name,fname=gname)
+        getter_declarations += declarations["member_getter"].format(type=klass, name=name,fname=gname, description=desc)
         getter_implementations += implementations["member_getter"].format(type=klass, classname=rawclassname, name=name, fname=gname)
         if klass in self.buildin_types:
-          setter_declarations += declarations["member_builtin_setter"].format(type=klass, name=name, fname=sname)
+          setter_declarations += declarations["member_builtin_setter"].format(type=klass, name=name, fname=sname, description=desc)
           setter_implementations += implementations["member_builtin_setter"].format(type=klass, classname=rawclassname, name=name, fname=sname)
         else:
-          setter_declarations += declarations["member_class_refsetter"].format(type=klass, name=name)
+          setter_declarations += declarations["member_class_refsetter"].format(type=klass, name=name, description=desc)
           setter_implementations += implementations["member_class_refsetter"].format(type=klass, classname=rawclassname, name=name, fname=sname)
-          setter_declarations += declarations["member_class_setter"].format(type=klass, name=name, fname=sname)
+          setter_declarations += declarations["member_class_setter"].format(type=klass, name=name, fname=sname, description=desc)
           setter_implementations += implementations["member_class_setter"].format(type=klass, classname=rawclassname, name=name, fname=sname)
+          if self.expose_pod_members:
+            sub_members = self.component_members[klass]
+            for sub_member in sub_members:
+              comp_member_class, comp_member_name = sub_member
+              comp_gname, comp_sname = comp_member_name, comp_member_name
+              if self.getSyntax:
+                comp_gname = "get" + comp_member_name[:1].upper() + comp_member_name[1:]
+                comp_sname = "set" + comp_member_name[:1].upper() + comp_member_name[1:]
+
+              getter_declarations += declarations["pod_member_getter"].format(type=comp_member_class, name=comp_member_name, fname=comp_gname, compname=name)
+              getter_implementations += implementations["pod_member_getter"].format(type=comp_member_class, classname=rawclassname, name=comp_member_name, fname=comp_gname, compname=name)
+              if comp_member_class in self.buildin_types:
+                setter_declarations += declarations["pod_member_builtin_setter"].format(type=comp_member_class, name=comp_member_name, fname=comp_sname, compname=name)
+                setter_implementations += implementations["pod_member_builtin_setter"].format(type=comp_member_class, classname=rawclassname, name=comp_member_name, fname=comp_sname, compname=name)
+              else:
+                setter_declarations += declarations["pod_member_class_refsetter"].format(type=comp_member_class, name=comp_member_name, compname=name)
+                setter_implementations += implementations["pod_member_class_refsetter"].format(type=comp_member_class, classname=rawclassname, name=comp_member_name, fname=comp_sname, compname=name)
+                setter_declarations += declarations["pod_member_class_setter"].format(type=comp_member_class, name=comp_member_name, fname=comp_sname, compname=name)
+                setter_implementations += implementations["pod_member_class_setter"].format(type=comp_member_class, classname=rawclassname, fname=comp_sname, name=comp_member_name, compname=name)
+              ConstGetter_implementations += implementations["const_pod_member_getter"].format(type=comp_member_class, classname=rawclassname, name=comp_member_name, fname=comp_gname, compname=name)
+
         # Getter for the Const variety of this datatype
-        ConstGetter_implementations += implementations["const_member_getter"].format(type=klass, classname=rawclassname, name=name, fname=gname)
+        ConstGetter_implementations += implementations["const_member_getter"].format(type=klass, classname=rawclassname, name=name, fname=gname, description=desc)
 
 
         # set up signature
@@ -283,15 +307,16 @@ class ClassGenerator(object):
       for member in oneToOneRelations:
           name = member["name"]
           klass = member["type"]
+          desc = member["description"]
           mnamespace = ""
           klassname = klass
           mnamespace, klassname, _, __ = self.demangle_classname(klass)
 
-          setter_declarations += declarations["one_rel_setter"].format(name=name, namespace=mnamespace, type=klassname)
+          setter_declarations += declarations["one_rel_setter"].format(name=name, namespace=mnamespace, type=klassname, description=desc)
           setter_implementations += implementations["one_rel_setter"].format(name=name, namespace=mnamespace, type=klassname, classname=rawclassname)
-          getter_declarations += declarations["one_rel_getter"].format(name=name, namespace=mnamespace, type=klassname)
+          getter_declarations += declarations["one_rel_getter"].format(name=name, namespace=mnamespace, type=klassname, description=desc)
           getter_implementations += implementations["one_rel_getter"].format(name=name, namespace=mnamespace, type=klassname, classname=rawclassname)
-          ConstGetter_implementations += implementations["const_one_rel_getter"].format(name=name, namespace=mnamespace, type=klassname, classname=rawclassname)
+          ConstGetter_implementations += implementations["const_one_rel_getter"].format(name=name, namespace=mnamespace, type=klassname, classname=rawclassname, description=desc)
 
 
       # handle vector members
@@ -634,7 +659,6 @@ class ClassGenerator(object):
       extracode_declarations = ""
       ostreamComponents = ""
       printed = [""]
-
       #fg: sort the dictionary, so at least we get a predictable order (alphabetical) of the members
       keys = sorted( components.keys() )
       for name in keys:
@@ -670,6 +694,7 @@ class ClassGenerator(object):
               members+= "  %s %s;\n" %(klassname, name)
           else:
             members += " ::%s::%s %s;\n" %(mnamespace, klassname, name)
+            self.component_members[classname].append(["::%s::%s" % (mnamespace, klassname), name])
           if self.reader.components.has_key(klass):
               includes+= '#include "%s.h"\n' %(klassname)
         else:
@@ -879,9 +904,6 @@ if __name__ == "__main__":
   parser.add_option("-q", "--quiet",
                     action="store_false", dest="verbose", default=True,
                     help="Don't write a report to screen")
-  parser.add_option("-g", "--getSyntax",
-                    action="store_true", dest="getSyntax", default=False,
-                    help="Create getter and setter members with getMember/setMember syntax")
   (options, args) = parser.parse_args()
 
   if len(args) != 3:
@@ -898,7 +920,7 @@ if __name__ == "__main__":
   if not os.path.exists( directory ):
     os.makedirs(directory)
 
-  gen = ClassGenerator(args[0], args[1], args[2], verbose = options.verbose, getSyntax=options.getSyntax )
+  gen = ClassGenerator(args[0], args[1], args[2], verbose = options.verbose)
   gen.process()
   for warning in gen.warnings:
       print warning

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -100,6 +100,11 @@ class PodioConfigReader(object):
         self.yamlfile = yamlfile
         self.datatypes = {}
         self.components = {}
+        self.options = {
+            # should getters / setters be prefixed with get / set?
+            "getSyntax": False,
+            # should POD members be exposed with getters/setters in classes that have them as members?
+            "exposePODMembers": True}
 
     @staticmethod
     def handle_extracode(definition):
@@ -140,3 +145,6 @@ class PodioConfigReader(object):
             for klassname, value in content["components"].iteritems():
                 component = {"Members": value}
                 self.components[klassname] = component
+        if "options" in content.keys():
+            for option, value in content["options"].iteritems():
+                self.options[option] = value

--- a/python/podio_templates.py
+++ b/python/podio_templates.py
@@ -56,6 +56,10 @@ implementations["clear_relations"]  = "\tfor (auto& item : (*m_rel_{name})) {{ i
 implementations["clear_relations"] += "\tm_rel_{name}->clear();\n"
 implementations["destroy_relations"]  = "\tif (m_rel_{name} != nullptr) {{ delete m_rel_{name}; }}\n"
 
+implementations["set_relations"]  = "\tif (other.m_{name} != nullptr) {{\n"
+implementations["set_relations"] += "\t\t m_{name} = new {klass}(*(other.m_{name}));\n"
+implementations["set_relations"] += "\t}}\n"
+
 implementations["prep_writing_relations"]  = "\tfor (auto& obj : m_entries) {{\n"
 implementations["prep_writing_relations"] += "\t\tif (obj->m_{name} != nullptr) {{\n"
 implementations["prep_writing_relations"] += "\t\t\tm_refCollections[{i}]->emplace_back(obj->m_{name}->getObjectID());\n"

--- a/python/podio_templates.py
+++ b/python/podio_templates.py
@@ -6,35 +6,68 @@ arguments = {}
 
 # Members
 #-----------------------------------
-declarations["member_getter"] = "\tconst {type}& {fname}() const;\n"
+declarations["member_getter"] =  "\t/// Access the {description}\n"
+declarations["member_getter"] += "\tconst {type}& {fname}() const;\n"
 implementations["member_getter"] = "\tconst {type}& {classname}::{fname}() const {{ return m_obj->data.{name}; }}\n"
 
-declarations["member_builtin_setter"] = "\tvoid {fname}({type} value);\n\n"
+declarations["member_builtin_setter"] =  "\t/// Set the {description}\n"
+declarations["member_builtin_setter"] += "\tvoid {fname}({type} value);\n\n"
 implementations["member_builtin_setter"] = "void {classname}::{fname}({type} value){{ m_obj->data.{name} = value; }}\n"
+
 # conceptually getting a non-const ref is a setter:
-declarations["member_class_refsetter"] = "\t{type}& {name}();\n"
+declarations["member_class_refsetter"] =  "\t/// Get reference to the {description}\n"
+declarations["member_class_refsetter"] += "\t{type}& {name}();\n"
 implementations["member_class_refsetter"] = "\t{type}& {classname}::{name}() {{ return m_obj->data.{name}; }}\n"
-declarations["member_class_setter"] = "\tvoid {fname}(class {type} value);\n"
+
+declarations["member_class_setter"] =  "\t/// Set the {description}\n"
+declarations["member_class_setter"] += "\tvoid {fname}(class {type} value);\n"
 implementations["member_class_setter"] = "void {classname}::{fname}(class {type} value) {{ m_obj->data.{name} = value; }}\n"
 
 # this is inline, don't need the declaration
-implementations["const_member_getter"] = "\tconst {type}& Const{classname}::{fname}() const {{ return m_obj->data.{name}; }}\n"
+implementations["const_member_getter"] =  "\t/// Access the {description}\n"
+implementations["const_member_getter"] += "\tconst {type}& Const{classname}::{fname}() const {{ return m_obj->data.{name}; }}\n"
+
+
+# currently no description of the POD members this could be re-added then
+# declarations["pod_member_getter"] =  "\t/// Access the {description}\n"
+declarations["pod_member_getter"] = "\tconst {type}& {fname}() const;\n"
+implementations["pod_member_getter"] = "const {type}& {classname}::{fname}() const {{ return m_obj->data.{compname}.{name}; }}\n"
+
+# declarations["pod_member_builtin_setter"] =  "\t/// Set the {description}\n"
+declarations["pod_member_builtin_setter"] = "\tvoid {fname}({type} value);\n\n"
+implementations["pod_member_builtin_setter"] = "void {classname}::{fname}({type} value){{ m_obj->data.{compname}.{name} = value; }}\n"
+
+# conceptually getting a non-const ref is a setter:
+# declarations["pod_member_class_refsetter"] =  "\t/// Get reference to the {description}\n"
+declarations["pod_member_class_refsetter"] = "\t{type}& {name}();\n"
+implementations["pod_member_class_refsetter"] = "{type}& {classname}::{name}() {{ return m_obj->data.{compname}.{name}; }}\n"
+
+# declarations["pod_member_class_setter"] =  "\t/// Set the {description}\n"
+declarations["pod_member_class_setter"] = "\tvoid {fname}(class {type} value);\n"
+implementations["pod_member_class_setter"] = "void {classname}::{fname}(class {type} value) {{ m_obj->data.{compname}.{name} = value; }}\n"
+
+# this is inline, don't need the declaration
+# implementations["const_member_getter"] =  "\t/// Access the {description}\n"
+implementations["const_pod_member_getter"] = "\tconst {type}& Const{classname}::{fname}() const {{ return m_obj->data.{compname}.{name}; }}\n"
 
 # OneToOneRelations
 #-----------------------------------
-declarations["one_rel_setter"] = "\tvoid {name}({namespace}::Const{type} value);\n"
+declarations["one_rel_setter"] =  "\t/// Set the {description}\n"
+declarations["one_rel_setter"] += "\tvoid {name}({namespace}::Const{type} value);\n"
 implementations["one_rel_setter"]  = "void {classname}::{name}({namespace}::Const{type} value) {{\n"
 implementations["one_rel_setter"] += "\tif (m_obj->m_{name} != nullptr) delete m_obj->m_{name};\n"
 implementations["one_rel_setter"] += "\tm_obj->m_{name} = new Const{type}(value);\n}}\n"
 
-declarations["one_rel_getter"] = "\tconst {namespace}::Const{type} {name}() const;\n"
+declarations["one_rel_getter"] =  "\t/// Access the {description}\n"
+declarations["one_rel_getter"] += "\tconst {namespace}::Const{type} {name}() const;\n"
 implementations["one_rel_getter"] = "\tconst {namespace}::Const{type} {classname}::{name}() const {{\n"
 implementations["one_rel_getter"] += "\t\tif (m_obj->m_{name} == nullptr) {{\n"
 implementations["one_rel_getter"] += "\t\t\treturn {namespace}::Const{type}(nullptr);\n"
 implementations["one_rel_getter"] += "\t\t}}\n"
 implementations["one_rel_getter"] += "\t\treturn {namespace}::Const{type}(*(m_obj->m_{name}));\n\t}}"
 # this is inline, don't need the declaration
-implementations["const_one_rel_getter"] = "\tconst {namespace}::Const{type} Const{classname}::{name}() const {{\n"
+implementations["const_one_rel_getter"] =  "\t/// Access the {description}\n"
+implementations["const_one_rel_getter"] += "\tconst {namespace}::Const{type} Const{classname}::{name}() const {{\n"
 implementations["const_one_rel_getter"] += "\t\tif (m_obj->m_{name} == nullptr) {{\n"
 implementations["const_one_rel_getter"] += "\t\t\treturn {namespace}::Const{type}(nullptr);\n"
 implementations["const_one_rel_getter"] += "\t\t}}\n"

--- a/python/test_EventStore.py
+++ b/python/test_EventStore.py
@@ -98,6 +98,12 @@ class EventStoreTestCase(unittest.TestCase):
         # so its event number should be 0.
         self.assertEqual(self.store[2000].get("info")[0].Number(), 0)
 
+    def test_context_managers(self):
+        with EventStore([self.filename]) as store:
+            self.assertTrue(len(store) >= 0)
+            self.assertTrue(store.isValid())
+
+
 if __name__ == "__main__":
     from ROOT import gSystem
     from subprocess import call

--- a/src/EventStore.cc
+++ b/src/EventStore.cc
@@ -38,6 +38,10 @@ namespace podio {
     return success;
   }
 
+  bool EventStore::isValid() const {
+    return m_reader->isValid();
+  }
+
   bool EventStore::doGet(const std::string& name, CollectionBase*& collection, bool setReferences) const {
     auto result = std::find_if(begin(m_collections), end(m_collections),
                                [name](const CollPair& item)->bool { return name==item.first; }

--- a/src/PythonEventStore.cc
+++ b/src/PythonEventStore.cc
@@ -26,3 +26,7 @@ void podio::PythonEventStore::goToEvent(unsigned ievent) {
 unsigned podio::PythonEventStore::getEntries() const {
   return m_reader.getEntries();
 }
+
+const std::vector<std::string>& podio::PythonEventStore::getCollectionNames() const {
+  return m_store.getCollectionIDTable()->names();
+}

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -85,6 +85,10 @@ namespace podio {
     readCollectionIDTable();
   }
 
+  void ROOTReader::closeFile() {
+    m_file->Close();
+  }
+
   void ROOTReader::readEvent(){
     m_eventTree->GetEntry();
     // first prepare all collections in memory...
@@ -96,6 +100,9 @@ namespace podio {
   //    inputs.first->setReferences(m_registry);
 
   //  }
+  }
+  bool ROOTReader::isValid() const {
+    return m_file->IsOpen() && !m_file->IsZombie();
   }
 
   ROOTReader::~ROOTReader() {

--- a/templates/Collection.cc.template
+++ b/templates/Collection.cc.template
@@ -14,7 +14,7 @@ ${name}Collection::~${name}Collection() {
   clear();
   if (m_data != nullptr) delete m_data;
   ${destructorbody}
-};
+}
 
 const ${name} ${name}Collection::operator[](unsigned int index) const {
   return ${name}(m_entries[index]);

--- a/templates/CollectionPrepareForWriting.cc.template
+++ b/templates/CollectionPrepareForWriting.cc.template
@@ -1,6 +1,6 @@
    (*m_data)[i].${name}_begin=${name}_index;
    (*m_data)[i].${name}_end+=${name}_index;
-   ${name}_index = (*m_data)[${name}_index].${name}_end;
+   ${name}_index = (*m_data)[i].${name}_end;
    for(auto it : (*m_rel_${name}_tmp[i])) {
      if (it.getObjectID().index == podio::ObjectID::untracked)
        throw std::runtime_error("Trying to persistify untracked object");

--- a/templates/Component.h.template
+++ b/templates/Component.h.template
@@ -2,11 +2,17 @@
 #define ${name}_H
 $includes
 
+#include <iostream>
+
 ${namespace_open}
 class $name {
 public:
 $members
 $extracode_declarations
 };
+
+${ostreamComponents}
+
 ${namespace_close}
+
 #endif

--- a/templates/ConstObject.h.template
+++ b/templates/ConstObject.h.template
@@ -4,9 +4,6 @@ $includes
 #include <vector>
 #include "podio/ObjectID.h"
 
-// $description
-// author: $author
-
 //forward declarations
 $forward_declarations
 
@@ -18,6 +15,11 @@ class ${name}Obj;
 class ${name};
 class ${name}Collection;
 class ${name}CollectionIterator;
+
+/** @class Const${name}
+ *  $description
+ *  @author: $author
+ */
 
 class Const${name} {
 

--- a/templates/Data.h.template
+++ b/templates/Data.h.template
@@ -1,12 +1,14 @@
 #ifndef ${name}DATA_H
 #define ${name}DATA_H
 
-// $description
-// author: $author
-
 $includes
 
 ${namespace_open}
+/** @class ${name}Data
+ *  $description
+ *  @author: $author
+ */
+
 class ${name}Data {
 public:
 $members

--- a/templates/Obj.cc.template
+++ b/templates/Obj.cc.template
@@ -13,7 +13,9 @@ ${name}Obj::${name}Obj(const podio::ObjectID id, ${name}Data data) :
 ${name}Obj::${name}Obj(const ${name}Obj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
     , data(other.data)${deepcopy_relations}
-{ }
+{
+${set_deepcopy_relations}
+}
 
 ${name}Obj::~${name}Obj() {
   if (id.index == podio::ObjectID::untracked) {

--- a/templates/Object.h.template
+++ b/templates/Object.h.template
@@ -4,9 +4,6 @@ $includes
 #include <vector>
 #include "podio/ObjectID.h"
 
-// $description
-// author: $author
-
 //forward declarations
 $forward_declarations
 
@@ -19,6 +16,10 @@ class ${name}Collection;
 class ${name}CollectionIterator;
 class Const${name};
 
+/** @class ${name}
+ *  $description
+ *  @author: $author
+ */
 class ${name} {
 
   friend ${name}Collection;

--- a/templates/PrintInfo.h.template
+++ b/templates/PrintInfo.h.template
@@ -1,0 +1,59 @@
+
+#ifndef  ${name}PrintInfo_h
+#define  ${name}PrintInfo_h
+
+#include "${name}Collection.h"
+
+class ${name}PrintInfo{
+
+ public:
+${widthOthers}
+${widthIntegers}
+  bool printWithTableHeader = false;
+ 
+  void setIntegerWidth(const ${name}Collection& value){
+      
+
+      /* sets the width in wich the ostream operators 
+         print out the integers of a given collection
+	 by rules of the function format */
+
+
+${findMaximum}
+
+${setFormats}	 
+
+  }   
+
+ static ${name}PrintInfo& instance(){
+        static ${name}PrintInfo _me;
+	return _me;
+  }
+ protected:
+  ${name}PrintInfo(){}
+
+  ~${name}PrintInfo(){}
+
+};
+
+ inline std::ostream& operator<<( std::ostream& o,const ${name}& value ){
+${outputSingleObject} std::endl ;
+	return o; 
+ }
+
+
+ inline std::ostream& operator<<( std::ostream& o,const ${name}Collection& value ){
+       ${name}PrintInfo::instance().setIntegerWidth(value);
+
+       if(${name}PrintInfo::instance().printWithTableHeader){o << ${tableHeader}std::endl;}
+
+       for(int i = 0; i < value.size(); i++){
+	       o << std::scientific << ${formattedOutput}  std::endl;
+	}
+
+	${name}PrintInfo::instance().printWithTableHeader = false;
+
+       return o;
+ }
+
+#endif

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -120,6 +120,8 @@ datatypes :
   ex::ExampleWithARelation :
     Description : "Type with namespace and namespaced relation"
     Author : "Joschka Lingemann"
+    Members:
+     - float number // just a number
     OneToOneRelations :
      - ex::ExampleWithNamespace ref // a ref in a namespace
     OneToManyRelations :

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -1,4 +1,10 @@
 ---
+options :
+  # should getters / setters be prefixed with get / set?
+  getSyntax: False
+  # should POD members be exposed with getters/setters in classes that have them as members?
+  exposePODMembers: True
+
 components :
   SimpleStruct:
     x : int

--- a/tests/datamodel/EventInfo.h
+++ b/tests/datamodel/EventInfo.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Event info
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -19,6 +16,10 @@ class EventInfoCollection;
 class EventInfoCollectionIterator;
 class ConstEventInfo;
 
+/** @class EventInfo
+ *  Event info
+ *  @author: B. Hegner
+ */
 class EventInfo {
 
   friend EventInfoCollection;
@@ -47,8 +48,10 @@ public:
 
 public:
 
+  /// Access the  event number
   const int& Number() const;
 
+  /// Set the  event number
   void Number(int value);
 
 

--- a/tests/datamodel/EventInfoConst.h
+++ b/tests/datamodel/EventInfoConst.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Event info
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -18,6 +15,11 @@ class EventInfoObj;
 class EventInfo;
 class EventInfoCollection;
 class EventInfoCollectionIterator;
+
+/** @class ConstEventInfo
+ *  Event info
+ *  @author: B. Hegner
+ */
 
 class ConstEventInfo {
 
@@ -45,6 +47,7 @@ public:
 
 public:
 
+  /// Access the  event number
   const int& Number() const;
 
 

--- a/tests/datamodel/EventInfoData.h
+++ b/tests/datamodel/EventInfoData.h
@@ -1,11 +1,13 @@
 #ifndef EventInfoDATA_H
 #define EventInfoDATA_H
 
-// Event info
-// author: B. Hegner
 
 
 
+/** @class EventInfoData
+ *  Event info
+ *  @author: B. Hegner
+ */
 
 class EventInfoData {
 public:

--- a/tests/datamodel/ExampleCluster.h
+++ b/tests/datamodel/ExampleCluster.h
@@ -7,9 +7,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Cluster
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -22,6 +19,10 @@ class ExampleClusterCollection;
 class ExampleClusterCollectionIterator;
 class ConstExampleCluster;
 
+/** @class ExampleCluster
+ *  Cluster
+ *  @author: B. Hegner
+ */
 class ExampleCluster {
 
   friend ExampleClusterCollection;
@@ -50,8 +51,10 @@ public:
 
 public:
 
+  /// Access the  cluster energy
   const double& energy() const;
 
+  /// Set the  cluster energy
   void energy(double value);
 
 

--- a/tests/datamodel/ExampleClusterConst.h
+++ b/tests/datamodel/ExampleClusterConst.h
@@ -7,9 +7,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Cluster
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -21,6 +18,11 @@ class ExampleClusterObj;
 class ExampleCluster;
 class ExampleClusterCollection;
 class ExampleClusterCollectionIterator;
+
+/** @class ConstExampleCluster
+ *  Cluster
+ *  @author: B. Hegner
+ */
 
 class ConstExampleCluster {
 
@@ -48,6 +50,7 @@ public:
 
 public:
 
+  /// Access the  cluster energy
   const double& energy() const;
 
   unsigned int Hits_size() const;

--- a/tests/datamodel/ExampleClusterData.h
+++ b/tests/datamodel/ExampleClusterData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleClusterDATA_H
 #define ExampleClusterDATA_H
 
-// Cluster
-// author: B. Hegner
 
 
 
+/** @class ExampleClusterData
+ *  Cluster
+ *  @author: B. Hegner
+ */
 
 class ExampleClusterData {
 public:

--- a/tests/datamodel/ExampleForCyclicDependency1.h
+++ b/tests/datamodel/ExampleForCyclicDependency1.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type for cyclic dependency
-// author: Benedikt Hegner
-
 //forward declarations
 class ExampleForCyclicDependency2;
 class ConstExampleForCyclicDependency2;
@@ -21,6 +18,10 @@ class ExampleForCyclicDependency1Collection;
 class ExampleForCyclicDependency1CollectionIterator;
 class ConstExampleForCyclicDependency1;
 
+/** @class ExampleForCyclicDependency1
+ *  Type for cyclic dependency
+ *  @author: Benedikt Hegner
+ */
 class ExampleForCyclicDependency1 {
 
   friend ExampleForCyclicDependency1Collection;
@@ -48,8 +49,10 @@ public:
 
 public:
 
+  /// Access the  a ref
   const ::ConstExampleForCyclicDependency2 ref() const;
 
+  /// Set the  a ref
   void ref(::ConstExampleForCyclicDependency2 value);
 
 

--- a/tests/datamodel/ExampleForCyclicDependency1Const.h
+++ b/tests/datamodel/ExampleForCyclicDependency1Const.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type for cyclic dependency
-// author: Benedikt Hegner
-
 //forward declarations
 class ExampleForCyclicDependency2;
 class ConstExampleForCyclicDependency2;
@@ -20,6 +17,11 @@ class ExampleForCyclicDependency1Obj;
 class ExampleForCyclicDependency1;
 class ExampleForCyclicDependency1Collection;
 class ExampleForCyclicDependency1CollectionIterator;
+
+/** @class ConstExampleForCyclicDependency1
+ *  Type for cyclic dependency
+ *  @author: Benedikt Hegner
+ */
 
 class ConstExampleForCyclicDependency1 {
 
@@ -46,6 +48,7 @@ public:
 
 public:
 
+  /// Access the  a ref
   const ::ConstExampleForCyclicDependency2 ref() const;
 
 

--- a/tests/datamodel/ExampleForCyclicDependency1Data.h
+++ b/tests/datamodel/ExampleForCyclicDependency1Data.h
@@ -1,11 +1,13 @@
 #ifndef ExampleForCyclicDependency1DATA_H
 #define ExampleForCyclicDependency1DATA_H
 
-// Type for cyclic dependency
-// author: Benedikt Hegner
 
 
 
+/** @class ExampleForCyclicDependency1Data
+ *  Type for cyclic dependency
+ *  @author: Benedikt Hegner
+ */
 
 class ExampleForCyclicDependency1Data {
 public:

--- a/tests/datamodel/ExampleForCyclicDependency2.h
+++ b/tests/datamodel/ExampleForCyclicDependency2.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type for cyclic dependency
-// author: Benedikt Hegner
-
 //forward declarations
 class ExampleForCyclicDependency1;
 class ConstExampleForCyclicDependency1;
@@ -21,6 +18,10 @@ class ExampleForCyclicDependency2Collection;
 class ExampleForCyclicDependency2CollectionIterator;
 class ConstExampleForCyclicDependency2;
 
+/** @class ExampleForCyclicDependency2
+ *  Type for cyclic dependency
+ *  @author: Benedikt Hegner
+ */
 class ExampleForCyclicDependency2 {
 
   friend ExampleForCyclicDependency2Collection;
@@ -48,8 +49,10 @@ public:
 
 public:
 
+  /// Access the  a ref
   const ::ConstExampleForCyclicDependency1 ref() const;
 
+  /// Set the  a ref
   void ref(::ConstExampleForCyclicDependency1 value);
 
 

--- a/tests/datamodel/ExampleForCyclicDependency2Const.h
+++ b/tests/datamodel/ExampleForCyclicDependency2Const.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type for cyclic dependency
-// author: Benedikt Hegner
-
 //forward declarations
 class ExampleForCyclicDependency1;
 class ConstExampleForCyclicDependency1;
@@ -20,6 +17,11 @@ class ExampleForCyclicDependency2Obj;
 class ExampleForCyclicDependency2;
 class ExampleForCyclicDependency2Collection;
 class ExampleForCyclicDependency2CollectionIterator;
+
+/** @class ConstExampleForCyclicDependency2
+ *  Type for cyclic dependency
+ *  @author: Benedikt Hegner
+ */
 
 class ConstExampleForCyclicDependency2 {
 
@@ -46,6 +48,7 @@ public:
 
 public:
 
+  /// Access the  a ref
   const ::ConstExampleForCyclicDependency1 ref() const;
 
 

--- a/tests/datamodel/ExampleForCyclicDependency2Data.h
+++ b/tests/datamodel/ExampleForCyclicDependency2Data.h
@@ -1,11 +1,13 @@
 #ifndef ExampleForCyclicDependency2DATA_H
 #define ExampleForCyclicDependency2DATA_H
 
-// Type for cyclic dependency
-// author: Benedikt Hegner
 
 
 
+/** @class ExampleForCyclicDependency2Data
+ *  Type for cyclic dependency
+ *  @author: Benedikt Hegner
+ */
 
 class ExampleForCyclicDependency2Data {
 public:

--- a/tests/datamodel/ExampleHit.h
+++ b/tests/datamodel/ExampleHit.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Example Hit
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -19,6 +16,10 @@ class ExampleHitCollection;
 class ExampleHitCollectionIterator;
 class ConstExampleHit;
 
+/** @class ExampleHit
+ *  Example Hit
+ *  @author: B. Hegner
+ */
 class ExampleHit {
 
   friend ExampleHitCollection;
@@ -47,17 +48,25 @@ public:
 
 public:
 
+  /// Access the  x-coordinate
   const double& x() const;
+  /// Access the  y-coordinate
   const double& y() const;
+  /// Access the  z-coordinate
   const double& z() const;
+  /// Access the  measured energy deposit
   const double& energy() const;
 
+  /// Set the  x-coordinate
   void x(double value);
 
+  /// Set the  y-coordinate
   void y(double value);
 
+  /// Set the  z-coordinate
   void z(double value);
 
+  /// Set the  measured energy deposit
   void energy(double value);
 
 

--- a/tests/datamodel/ExampleHitConst.h
+++ b/tests/datamodel/ExampleHitConst.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Example Hit
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -18,6 +15,11 @@ class ExampleHitObj;
 class ExampleHit;
 class ExampleHitCollection;
 class ExampleHitCollectionIterator;
+
+/** @class ConstExampleHit
+ *  Example Hit
+ *  @author: B. Hegner
+ */
 
 class ConstExampleHit {
 
@@ -45,9 +47,13 @@ public:
 
 public:
 
+  /// Access the  x-coordinate
   const double& x() const;
+  /// Access the  y-coordinate
   const double& y() const;
+  /// Access the  z-coordinate
   const double& z() const;
+  /// Access the  measured energy deposit
   const double& energy() const;
 
 

--- a/tests/datamodel/ExampleHitData.h
+++ b/tests/datamodel/ExampleHitData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleHitDATA_H
 #define ExampleHitDATA_H
 
-// Example Hit
-// author: B. Hegner
 
 
 
+/** @class ExampleHitData
+ *  Example Hit
+ *  @author: B. Hegner
+ */
 
 class ExampleHitData {
 public:

--- a/tests/datamodel/ExampleMC.h
+++ b/tests/datamodel/ExampleMC.h
@@ -7,9 +7,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Example MC-particle
-// author: F.Gaede
-
 //forward declarations
 
 
@@ -22,6 +19,10 @@ class ExampleMCCollection;
 class ExampleMCCollectionIterator;
 class ConstExampleMC;
 
+/** @class ExampleMC
+ *  Example MC-particle
+ *  @author: F.Gaede
+ */
 class ExampleMC {
 
   friend ExampleMCCollection;
@@ -50,11 +51,15 @@ public:
 
 public:
 
+  /// Access the  energy
   const double& energy() const;
+  /// Access the  PDG code
   const int& PDG() const;
 
+  /// Set the  energy
   void energy(double value);
 
+  /// Set the  PDG code
   void PDG(int value);
 
 

--- a/tests/datamodel/ExampleMCConst.h
+++ b/tests/datamodel/ExampleMCConst.h
@@ -7,9 +7,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Example MC-particle
-// author: F.Gaede
-
 //forward declarations
 
 
@@ -21,6 +18,11 @@ class ExampleMCObj;
 class ExampleMC;
 class ExampleMCCollection;
 class ExampleMCCollectionIterator;
+
+/** @class ConstExampleMC
+ *  Example MC-particle
+ *  @author: F.Gaede
+ */
 
 class ConstExampleMC {
 
@@ -48,7 +50,9 @@ public:
 
 public:
 
+  /// Access the  energy
   const double& energy() const;
+  /// Access the  PDG code
   const int& PDG() const;
 
   unsigned int parents_size() const;

--- a/tests/datamodel/ExampleMCData.h
+++ b/tests/datamodel/ExampleMCData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleMCDATA_H
 #define ExampleMCDATA_H
 
-// Example MC-particle
-// author: F.Gaede
 
 
 
+/** @class ExampleMCData
+ *  Example MC-particle
+ *  @author: F.Gaede
+ */
 
 class ExampleMCData {
 public:

--- a/tests/datamodel/ExampleReferencingType.h
+++ b/tests/datamodel/ExampleReferencingType.h
@@ -7,9 +7,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Referencing Type
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -22,6 +19,10 @@ class ExampleReferencingTypeCollection;
 class ExampleReferencingTypeCollectionIterator;
 class ConstExampleReferencingType;
 
+/** @class ExampleReferencingType
+ *  Referencing Type
+ *  @author: B. Hegner
+ */
 class ExampleReferencingType {
 
   friend ExampleReferencingTypeCollection;

--- a/tests/datamodel/ExampleReferencingTypeConst.h
+++ b/tests/datamodel/ExampleReferencingTypeConst.h
@@ -7,9 +7,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Referencing Type
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -21,6 +18,11 @@ class ExampleReferencingTypeObj;
 class ExampleReferencingType;
 class ExampleReferencingTypeCollection;
 class ExampleReferencingTypeCollectionIterator;
+
+/** @class ConstExampleReferencingType
+ *  Referencing Type
+ *  @author: B. Hegner
+ */
 
 class ConstExampleReferencingType {
 

--- a/tests/datamodel/ExampleReferencingTypeData.h
+++ b/tests/datamodel/ExampleReferencingTypeData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleReferencingTypeDATA_H
 #define ExampleReferencingTypeDATA_H
 
-// Referencing Type
-// author: B. Hegner
 
 
 
+/** @class ExampleReferencingTypeData
+ *  Referencing Type
+ *  @author: B. Hegner
+ */
 
 class ExampleReferencingTypeData {
 public:

--- a/tests/datamodel/ExampleWithARelation.h
+++ b/tests/datamodel/ExampleWithARelation.h
@@ -6,9 +6,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with namespace and namespaced relation
-// author: Joschka Lingemann
-
 //forward declarations
 namespace ex {
 class ExampleWithNamespace;
@@ -25,6 +22,10 @@ class ExampleWithARelationCollection;
 class ExampleWithARelationCollectionIterator;
 class ConstExampleWithARelation;
 
+/** @class ExampleWithARelation
+ *  Type with namespace and namespaced relation
+ *  @author: Joschka Lingemann
+ */
 class ExampleWithARelation {
 
   friend ExampleWithARelationCollection;
@@ -53,11 +54,15 @@ public:
 
 public:
 
+  /// Access the  just a number
   const float& number() const;
+  /// Access the  a ref in a namespace
   const ex::ConstExampleWithNamespace ref() const;
 
+  /// Set the  just a number
   void number(float value);
 
+  /// Set the  a ref in a namespace
   void ref(ex::ConstExampleWithNamespace value);
 
   void addrefs(ex::ConstExampleWithNamespace);

--- a/tests/datamodel/ExampleWithARelation.h
+++ b/tests/datamodel/ExampleWithARelation.h
@@ -35,6 +35,7 @@ public:
 
   /// default constructor
   ExampleWithARelation();
+  ExampleWithARelation(float number);
 
   /// constructor from existing ExampleWithARelationObj
   ExampleWithARelation(ExampleWithARelationObj* obj);
@@ -52,7 +53,10 @@ public:
 
 public:
 
+  const float& number() const;
   const ex::ConstExampleWithNamespace ref() const;
+
+  void number(float value);
 
   void ref(ex::ConstExampleWithNamespace value);
 

--- a/tests/datamodel/ExampleWithARelationCollection.h
+++ b/tests/datamodel/ExampleWithARelationCollection.h
@@ -107,7 +107,9 @@ public:
   /// returns the pointer to the data buffer
   std::vector<ExampleWithARelationData>* _getBuffer() { return m_data;};
 
-   
+    template<size_t arraysize>
+  const std::array<float,arraysize> number() const;
+
 
 private:
   bool m_isValid;
@@ -131,6 +133,15 @@ ExampleWithARelation  ExampleWithARelationCollection::create(Args&&... args){
   return ExampleWithARelation(obj);
 }
 
+template<size_t arraysize>
+const std::array<float,arraysize> ExampleWithARelationCollection::number() const {
+  std::array<float,arraysize> tmp;
+  auto valid_size = std::min(arraysize,m_entries.size());
+  for (unsigned i = 0; i<valid_size; ++i){
+    tmp[i] = m_entries[i]->data.number;
+ }
+ return tmp;
+}
 
 } // namespace ex
 #endif

--- a/tests/datamodel/ExampleWithARelationConst.h
+++ b/tests/datamodel/ExampleWithARelationConst.h
@@ -35,7 +35,8 @@ public:
 
   /// default constructor
   ConstExampleWithARelation();
-  
+  ConstExampleWithARelation(float number);
+
   /// constructor from existing ExampleWithARelationObj
   ConstExampleWithARelation(ExampleWithARelationObj* obj);
   /// copy constructor
@@ -50,6 +51,7 @@ public:
 
 public:
 
+  const float& number() const;
   const ex::ConstExampleWithNamespace ref() const;
 
   unsigned int refs_size() const;

--- a/tests/datamodel/ExampleWithARelationConst.h
+++ b/tests/datamodel/ExampleWithARelationConst.h
@@ -6,9 +6,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with namespace and namespaced relation
-// author: Joschka Lingemann
-
 //forward declarations
 namespace ex {
 class ExampleWithNamespace;
@@ -24,6 +21,11 @@ class ExampleWithARelationObj;
 class ExampleWithARelation;
 class ExampleWithARelationCollection;
 class ExampleWithARelationCollectionIterator;
+
+/** @class ConstExampleWithARelation
+ *  Type with namespace and namespaced relation
+ *  @author: Joschka Lingemann
+ */
 
 class ConstExampleWithARelation {
 
@@ -51,7 +53,9 @@ public:
 
 public:
 
+  /// Access the  just a number
   const float& number() const;
+  /// Access the  a ref in a namespace
   const ex::ConstExampleWithNamespace ref() const;
 
   unsigned int refs_size() const;

--- a/tests/datamodel/ExampleWithARelationData.h
+++ b/tests/datamodel/ExampleWithARelationData.h
@@ -1,12 +1,14 @@
 #ifndef ExampleWithARelationDATA_H
 #define ExampleWithARelationDATA_H
 
-// Type with namespace and namespaced relation
-// author: Joschka Lingemann
-
 
 
 namespace ex {
+/** @class ExampleWithARelationData
+ *  Type with namespace and namespaced relation
+ *  @author: Joschka Lingemann
+ */
+
 class ExampleWithARelationData {
 public:
   float number;  ///< just a number

--- a/tests/datamodel/ExampleWithARelationData.h
+++ b/tests/datamodel/ExampleWithARelationData.h
@@ -9,6 +9,7 @@
 namespace ex {
 class ExampleWithARelationData {
 public:
+  float number;  ///< just a number
   unsigned int refs_begin;
   unsigned int refs_end;
 };

--- a/tests/datamodel/ExampleWithComponent.h
+++ b/tests/datamodel/ExampleWithComponent.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with one component
-// author: Benedikt Hegner
-
 //forward declarations
 
 
@@ -20,6 +17,10 @@ class ExampleWithComponentCollection;
 class ExampleWithComponentCollectionIterator;
 class ConstExampleWithComponent;
 
+/** @class ExampleWithComponent
+ *  Type with one component
+ *  @author: Benedikt Hegner
+ */
 class ExampleWithComponent {
 
   friend ExampleWithComponentCollection;
@@ -48,10 +49,16 @@ public:
 
 public:
 
+  /// Access the  a component
   const NotSoSimpleStruct& component() const;
+  const SimpleStruct& data() const;
 
+  /// Get reference to the  a component
   NotSoSimpleStruct& component();
+  /// Set the  a component
   void component(class NotSoSimpleStruct value);
+  SimpleStruct& data();
+  void data(class SimpleStruct value);
 
 
 

--- a/tests/datamodel/ExampleWithComponentConst.h
+++ b/tests/datamodel/ExampleWithComponentConst.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with one component
-// author: Benedikt Hegner
-
 //forward declarations
 
 
@@ -19,6 +16,11 @@ class ExampleWithComponentObj;
 class ExampleWithComponent;
 class ExampleWithComponentCollection;
 class ExampleWithComponentCollectionIterator;
+
+/** @class ConstExampleWithComponent
+ *  Type with one component
+ *  @author: Benedikt Hegner
+ */
 
 class ConstExampleWithComponent {
 
@@ -46,7 +48,9 @@ public:
 
 public:
 
+  /// Access the  a component
   const NotSoSimpleStruct& component() const;
+  const SimpleStruct& data() const;
 
 
 

--- a/tests/datamodel/ExampleWithComponentData.h
+++ b/tests/datamodel/ExampleWithComponentData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleWithComponentDATA_H
 #define ExampleWithComponentDATA_H
 
-// Type with one component
-// author: Benedikt Hegner
-
 #include "NotSoSimpleStruct.h"
 
+
+/** @class ExampleWithComponentData
+ *  Type with one component
+ *  @author: Benedikt Hegner
+ */
 
 class ExampleWithComponentData {
 public:

--- a/tests/datamodel/ExampleWithNamespace.h
+++ b/tests/datamodel/ExampleWithNamespace.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with namespace and namespaced member
-// author: Joschka Lingemann
-
 //forward declarations
 
 
@@ -20,6 +17,10 @@ class ExampleWithNamespaceCollection;
 class ExampleWithNamespaceCollectionIterator;
 class ConstExampleWithNamespace;
 
+/** @class ExampleWithNamespace
+ *  Type with namespace and namespaced member
+ *  @author: Joschka Lingemann
+ */
 class ExampleWithNamespace {
 
   friend ExampleWithNamespaceCollection;
@@ -48,10 +49,19 @@ public:
 
 public:
 
+  /// Access the  a component
   const ex2::NamespaceStruct& data() const;
+  const int& x() const;
+  const int& y() const;
 
+  /// Get reference to the  a component
   ex2::NamespaceStruct& data();
+  /// Set the  a component
   void data(class ex2::NamespaceStruct value);
+  void x(int value);
+
+  void y(int value);
+
 
 
 

--- a/tests/datamodel/ExampleWithNamespaceConst.h
+++ b/tests/datamodel/ExampleWithNamespaceConst.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with namespace and namespaced member
-// author: Joschka Lingemann
-
 //forward declarations
 
 
@@ -19,6 +16,11 @@ class ExampleWithNamespaceObj;
 class ExampleWithNamespace;
 class ExampleWithNamespaceCollection;
 class ExampleWithNamespaceCollectionIterator;
+
+/** @class ConstExampleWithNamespace
+ *  Type with namespace and namespaced member
+ *  @author: Joschka Lingemann
+ */
 
 class ConstExampleWithNamespace {
 
@@ -46,7 +48,10 @@ public:
 
 public:
 
+  /// Access the  a component
   const ex2::NamespaceStruct& data() const;
+  const int& x() const;
+  const int& y() const;
 
 
 

--- a/tests/datamodel/ExampleWithNamespaceData.h
+++ b/tests/datamodel/ExampleWithNamespaceData.h
@@ -1,12 +1,14 @@
 #ifndef ExampleWithNamespaceDATA_H
 #define ExampleWithNamespaceDATA_H
 
-// Type with namespace and namespaced member
-// author: Joschka Lingemann
-
 #include "NamespaceStruct.h"
 
 namespace ex {
+/** @class ExampleWithNamespaceData
+ *  Type with namespace and namespaced member
+ *  @author: Joschka Lingemann
+ */
+
 class ExampleWithNamespaceData {
 public:
   ex2::NamespaceStruct data;  ///< a component

--- a/tests/datamodel/ExampleWithOneRelation.h
+++ b/tests/datamodel/ExampleWithOneRelation.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with one relation member
-// author: Benedikt Hegner
-
 //forward declarations
 class ExampleCluster;
 class ConstExampleCluster;
@@ -21,6 +18,10 @@ class ExampleWithOneRelationCollection;
 class ExampleWithOneRelationCollectionIterator;
 class ConstExampleWithOneRelation;
 
+/** @class ExampleWithOneRelation
+ *  Type with one relation member
+ *  @author: Benedikt Hegner
+ */
 class ExampleWithOneRelation {
 
   friend ExampleWithOneRelationCollection;
@@ -48,8 +49,10 @@ public:
 
 public:
 
+  /// Access the  a particular cluster
   const ::ConstExampleCluster cluster() const;
 
+  /// Set the  a particular cluster
   void cluster(::ConstExampleCluster value);
 
 

--- a/tests/datamodel/ExampleWithOneRelationConst.h
+++ b/tests/datamodel/ExampleWithOneRelationConst.h
@@ -4,9 +4,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with one relation member
-// author: Benedikt Hegner
-
 //forward declarations
 class ExampleCluster;
 class ConstExampleCluster;
@@ -20,6 +17,11 @@ class ExampleWithOneRelationObj;
 class ExampleWithOneRelation;
 class ExampleWithOneRelationCollection;
 class ExampleWithOneRelationCollectionIterator;
+
+/** @class ConstExampleWithOneRelation
+ *  Type with one relation member
+ *  @author: Benedikt Hegner
+ */
 
 class ConstExampleWithOneRelation {
 
@@ -46,6 +48,7 @@ public:
 
 public:
 
+  /// Access the  a particular cluster
   const ::ConstExampleCluster cluster() const;
 
 

--- a/tests/datamodel/ExampleWithOneRelationData.h
+++ b/tests/datamodel/ExampleWithOneRelationData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleWithOneRelationDATA_H
 #define ExampleWithOneRelationDATA_H
 
-// Type with one relation member
-// author: Benedikt Hegner
 
 
 
+/** @class ExampleWithOneRelationData
+ *  Type with one relation member
+ *  @author: Benedikt Hegner
+ */
 
 class ExampleWithOneRelationData {
 public:

--- a/tests/datamodel/ExampleWithString.h
+++ b/tests/datamodel/ExampleWithString.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with a string
-// author: Benedikt Hegner
-
 //forward declarations
 
 
@@ -20,6 +17,10 @@ class ExampleWithStringCollection;
 class ExampleWithStringCollectionIterator;
 class ConstExampleWithString;
 
+/** @class ExampleWithString
+ *  Type with a string
+ *  @author: Benedikt Hegner
+ */
 class ExampleWithString {
 
   friend ExampleWithStringCollection;
@@ -48,8 +49,10 @@ public:
 
 public:
 
+  /// Access the  the string
   const std::string& theString() const;
 
+  /// Set the  the string
   void theString(std::string value);
 
 

--- a/tests/datamodel/ExampleWithStringConst.h
+++ b/tests/datamodel/ExampleWithStringConst.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with a string
-// author: Benedikt Hegner
-
 //forward declarations
 
 
@@ -19,6 +16,11 @@ class ExampleWithStringObj;
 class ExampleWithString;
 class ExampleWithStringCollection;
 class ExampleWithStringCollectionIterator;
+
+/** @class ConstExampleWithString
+ *  Type with a string
+ *  @author: Benedikt Hegner
+ */
 
 class ConstExampleWithString {
 
@@ -46,6 +48,7 @@ public:
 
 public:
 
+  /// Access the  the string
   const std::string& theString() const;
 
 

--- a/tests/datamodel/ExampleWithStringData.h
+++ b/tests/datamodel/ExampleWithStringData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleWithStringDATA_H
 #define ExampleWithStringDATA_H
 
-// Type with a string
-// author: Benedikt Hegner
-
 #include <string>
 
+
+/** @class ExampleWithStringData
+ *  Type with a string
+ *  @author: Benedikt Hegner
+ */
 
 class ExampleWithStringData {
 public:

--- a/tests/datamodel/ExampleWithVectorMember.h
+++ b/tests/datamodel/ExampleWithVectorMember.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with a vector member
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -20,6 +17,10 @@ class ExampleWithVectorMemberCollection;
 class ExampleWithVectorMemberCollectionIterator;
 class ConstExampleWithVectorMember;
 
+/** @class ExampleWithVectorMember
+ *  Type with a vector member
+ *  @author: B. Hegner
+ */
 class ExampleWithVectorMember {
 
   friend ExampleWithVectorMemberCollection;

--- a/tests/datamodel/ExampleWithVectorMemberConst.h
+++ b/tests/datamodel/ExampleWithVectorMemberConst.h
@@ -5,9 +5,6 @@
 #include <vector>
 #include "podio/ObjectID.h"
 
-// Type with a vector member
-// author: B. Hegner
-
 //forward declarations
 
 
@@ -19,6 +16,11 @@ class ExampleWithVectorMemberObj;
 class ExampleWithVectorMember;
 class ExampleWithVectorMemberCollection;
 class ExampleWithVectorMemberCollectionIterator;
+
+/** @class ConstExampleWithVectorMember
+ *  Type with a vector member
+ *  @author: B. Hegner
+ */
 
 class ConstExampleWithVectorMember {
 

--- a/tests/datamodel/ExampleWithVectorMemberData.h
+++ b/tests/datamodel/ExampleWithVectorMemberData.h
@@ -1,11 +1,13 @@
 #ifndef ExampleWithVectorMemberDATA_H
 #define ExampleWithVectorMemberDATA_H
 
-// Type with a vector member
-// author: B. Hegner
 
 
 
+/** @class ExampleWithVectorMemberData
+ *  Type with a vector member
+ *  @author: B. Hegner
+ */
 
 class ExampleWithVectorMemberData {
 public:

--- a/tests/datamodel/NamespaceInNamespaceStruct.h
+++ b/tests/datamodel/NamespaceInNamespaceStruct.h
@@ -3,6 +3,8 @@
 #include "NamespaceStruct.h"
 
 
+#include <iostream>
+
 namespace ex2 {
 class NamespaceInNamespaceStruct {
 public:
@@ -10,5 +12,9 @@ public:
 
 
 };
+
+
+
 } // namespace ex2
+
 #endif

--- a/tests/datamodel/NamespaceStruct.h
+++ b/tests/datamodel/NamespaceStruct.h
@@ -2,6 +2,8 @@
 #define NamespaceStruct_H
 
 
+#include <iostream>
+
 namespace ex2 {
 class NamespaceStruct {
 public:
@@ -10,5 +12,9 @@ public:
 
 
 };
+
+
+
 } // namespace ex2
+
 #endif

--- a/tests/datamodel/NotSoSimpleStruct.h
+++ b/tests/datamodel/NotSoSimpleStruct.h
@@ -3,6 +3,8 @@
 #include "SimpleStruct.h"
 
 
+#include <iostream>
+
 
 class NotSoSimpleStruct {
 public:
@@ -10,5 +12,9 @@ public:
 
 
 };
+
+
+
+
 
 #endif

--- a/tests/datamodel/SimpleStruct.h
+++ b/tests/datamodel/SimpleStruct.h
@@ -2,6 +2,8 @@
 #define SimpleStruct_H
 
 
+#include <iostream>
+
 
 class SimpleStruct {
 public:
@@ -11,5 +13,9 @@ public:
 
  SimpleStruct() : x(0),y(0),z(0) {} SimpleStruct( const int* v) : x(v[0]),y(v[1]),z(v[2]) {} 
 };
+
+
+
+
 
 #endif

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -103,14 +103,26 @@ void processEvent(podio::EventStore& store, bool verboser) {
 
   auto& nmspaces = store.get<ex::ExampleWithARelationCollection>("WithNamespaceRelation");
   auto& copies = store.get<ex::ExampleWithARelationCollection>("WithNamespaceRelationCopy");
-  if (nmspaces.isValid()) {
-    auto nmsp = nmspaces[0];
-    int b = nmsp.ref().data().x + nmsp.ref().data().y;
-    assert(nmsp.ref().data().x == nmsp.refs_begin()->data().x);
-    auto cpy = copies[0];
-    assert(nmsp.ref().data().x == cpy.ref().data().x);
-    assert(nmsp.refs_begin()->data().x == cpy.refs_begin()->data().x);
-    assert(nmsp.number() == cpy.number());
+  auto& cpytest = store.create<ex::ExampleWithARelationCollection>("TestConstCopy");
+  assert(nmspaces.isValid() && copies.isValid());
+  for (int j = 0; j < nmspaces.size(); j++) {
+    auto nmsp = nmspaces[j];
+    auto cpy = copies[j];
+    cpytest.push_back(nmsp.clone());
+    if (nmsp.ref().isAvailable()) {
+      assert(nmsp.ref().data().x == cpy.ref().data().x);
+      assert(nmsp.ref().data().y == cpy.ref().data().y);
+      assert(nmsp.number() == cpy.number());
+      assert(nmsp.ref().getObjectID() == cpy.ref().getObjectID());
+    }
+    auto cpy_it = cpy.refs_begin();
+    for (auto it = nmsp.refs_begin(); it != nmsp.refs_end(); ++it, ++cpy_it) {
+      std::cout << it->data().x << std::endl;
+      std::cout << cpy_it->data().x << std::endl;
+      assert(it->data().x == cpy_it->data().x);
+      assert(it->data().y == cpy_it->data().y);
+      assert(it->getObjectID() == cpy_it->getObjectID());
+    }
   }
 }
 

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 #include <iostream>
 #include <exception>
+#include <cassert>
 
 // podio specific includes
 #include "podio/EventStore.h"
@@ -101,9 +102,15 @@ void processEvent(podio::EventStore& store, bool verboser) {
   }
 
   auto& nmspaces = store.get<ex::ExampleWithARelationCollection>("WithNamespaceRelation");
+  auto& copies = store.get<ex::ExampleWithARelationCollection>("WithNamespaceRelationCopy");
   if (nmspaces.isValid()) {
     auto nmsp = nmspaces[0];
     int b = nmsp.ref().data().x + nmsp.ref().data().y;
+    assert(nmsp.ref().data().x == nmsp.refs_begin()->data().x);
+    auto cpy = copies[0];
+    assert(nmsp.ref().data().x == cpy.ref().data().x);
+    assert(nmsp.refs_begin()->data().x == cpy.refs_begin()->data().x);
+    assert(nmsp.number() == cpy.number());
   }
 }
 

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -153,22 +153,22 @@ void processEvent(podio::EventStore& store, bool verboser) {
       cpytest.push_back(nmsp.clone());
       if (nmsp.ref().isAvailable()) {
         if (nmsp.ref().data().x != cpy.ref().data().x || nmsp.ref().data().y != cpy.ref().data().y) {
-          throw std::runtime_error("Copied item has differing data in OneToOne referenced item.")
+          throw std::runtime_error("Copied item has differing data in OneToOne referenced item.");
         }
         if (nmsp.number() != cpy.number()) {
-          throw std::runtime_error("Copied item has differing member.")
+          throw std::runtime_error("Copied item has differing member.");
         }
-        if (nmsp.ref().getObjectID() != cpy.ref().getObjectID()) {
-          throw std::runtime_error("Copied item has wrong OneToOne references.")
+        if (!(nmsp.ref().getObjectID() == cpy.ref().getObjectID())) {
+          throw std::runtime_error("Copied item has wrong OneToOne references.");
         }
       }
       auto cpy_it = cpy.refs_begin();
       for (auto it = nmsp.refs_begin(); it != nmsp.refs_end(); ++it, ++cpy_it) {
         if (it->data().x != cpy_it->data().x || it->data().y != cpy_it->data().y) {
-          throw std::runtime_error("Copied item has differing data in OneToMany referenced item.")
+          throw std::runtime_error("Copied item has differing data in OneToMany referenced item.");
         }
-        if (it->getObjectID() != cpy_it->getObjectID()) {
-          throw std::runtime_error("Copied item has wrong OneToMany references.")
+        if (!(it->getObjectID() == cpy_it->getObjectID())) {
+          throw std::runtime_error("Copied item has wrong OneToMany references.");
         }
       }
     }

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -32,9 +32,11 @@ void processEvent(podio::EventStore& store, bool verboser) {
   auto& strings = store.get<ExampleWithStringCollection>("strings");
   if(strings.isValid()){
     auto string = strings[0];
-    if (string.theString() != "SomeString") { 
+    if (string.theString() != "SomeString") {
       throw std::runtime_error("Couldn't read string properly");
     }
+  } else {
+    throw std::runtime_error("Collection 'strings' should be present.");
   }
   //std::cout << "Fetching collection 'clusters'" << std::endl;
   auto& clusters = store.get<ExampleClusterCollection>("clusters");
@@ -45,40 +47,28 @@ void processEvent(podio::EventStore& store, bool verboser) {
       std::cout << "  Referenced hit has an energy of " << i->energy() << std::endl;
       glob++;
     }
+  } else {
+    throw std::runtime_error("Collection 'clusters' should be present");
   }
 
 
   auto& mcps =  store.get<ExampleMCCollection>("mcparticles");
   if( mcps.isValid() ){
-
-    // for( auto p : mcps ){
-    //   std::cout << " particle " << p.getObjectID().index << " daughters: " ;
-    //   for(auto it = p.daughters_begin(), end = p.daughters_end() ; it!=end ; ++it ){
-    // 	int dIndex = it->getObjectID().index ;
-    // 	std::cout << " " << dIndex ;
-    //   } 
-    //   std::cout << "  and parents: " ;
-    //   for(auto it = p.parents_begin(), end = p.parents_end() ; it!=end ; ++it ){
-    // 	std::cout << " " << it->getObjectID().index ;
-    //   }
-    //   std::cout << std::endl ;
-    // }
-
     // check that we can retrieve the correct parent daughter relation
     // set in write.cpp :
 
-    // particle 0 has particles 2,3,4 and 5 as daughters: 
+    // particle 0 has particles 2,3,4 and 5 as daughters:
     auto p = mcps[0] ;
 
     //-------- print relations for debugging:
     for( auto p : mcps ){
       std::cout << " particle " << p.getObjectID().index << " has daughters: " ;
       for(auto it = p.daughters_begin(), end = p.daughters_end() ; it!=end ; ++it ){
-	std::cout << " " << it->getObjectID().index ;
+        std::cout << " " << it->getObjectID().index ;
       }
       std::cout << "  and parents: " ;
       for(auto it = p.parents_begin(), end = p.parents_end() ; it!=end ; ++it ){
-	std::cout << " " << it->getObjectID().index ;
+        std::cout << " " << it->getObjectID().index ;
       }
       std::cout << std::endl ;
     }
@@ -87,11 +77,11 @@ void processEvent(podio::EventStore& store, bool verboser) {
     auto d1 = p.daughters(1) ;
     auto d2 = p.daughters(2) ;
     auto d3 = p.daughters(3) ;
-    
-    if( ! ( d0 == mcps[2] ) )  throw std::runtime_error(" error: 1. daughter of particle 0 is not particle 2 " ) ;  
-    if( ! ( d1 == mcps[3] ) )  throw std::runtime_error(" error: 2. daughter of particle 0 is not particle 3 " ) ;  
-    if( ! ( d2 == mcps[4] ) )  throw std::runtime_error(" error: 3. daughter of particle 0 is not particle 4 " ) ;  
-    if( ! ( d3 == mcps[5] ) )  throw std::runtime_error(" error: 4. daughter of particle 0 is not particle 5 " ) ;  
+
+    if( ! ( d0 == mcps[2] ) )  throw std::runtime_error(" error: 1. daughter of particle 0 is not particle 2 ");
+    if( ! ( d1 == mcps[3] ) )  throw std::runtime_error(" error: 2. daughter of particle 0 is not particle 3 ");
+    if( ! ( d2 == mcps[4] ) )  throw std::runtime_error(" error: 3. daughter of particle 0 is not particle 4 ");
+    if( ! ( d3 == mcps[5] ) )  throw std::runtime_error(" error: 4. daughter of particle 0 is not particle 5 ");
 
 
     // particle 3 has particles 6,7,8 and 9 as daughters: 
@@ -101,12 +91,14 @@ void processEvent(podio::EventStore& store, bool verboser) {
     d1 = p.daughters(1) ;
     d2 = p.daughters(2) ;
     d3 = p.daughters(3) ;
-    
-    if( ! ( d0 == mcps[6] ) )  throw std::runtime_error(" error: 1. daughter of particle 3 is not particle 6 " ) ;  
-    if( ! ( d1 == mcps[7] ) )  throw std::runtime_error(" error: 2. daughter of particle 3 is not particle 7 " ) ;  
-    if( ! ( d2 == mcps[8] ) )  throw std::runtime_error(" error: 3. daughter of particle 3 is not particle 8 " ) ;  
-    if( ! ( d3 == mcps[9] ) )  throw std::runtime_error(" error: 4. daughter of particle 3 is not particle 9 " ) ;  
 
+    if( ! ( d0 == mcps[6] ) )  throw std::runtime_error(" error: 1. daughter of particle 3 is not particle 6 ");
+    if( ! ( d1 == mcps[7] ) )  throw std::runtime_error(" error: 2. daughter of particle 3 is not particle 7 ");
+    if( ! ( d2 == mcps[8] ) )  throw std::runtime_error(" error: 3. daughter of particle 3 is not particle 8 ");
+    if( ! ( d3 == mcps[9] ) )  throw std::runtime_error(" error: 4. daughter of particle 3 is not particle 9 ");
+
+  } else {
+    throw std::runtime_error("Collection 'mcparticles' should be present");
   }
 
 
@@ -120,12 +112,16 @@ void processEvent(podio::EventStore& store, bool verboser) {
         glob++;
       }
     }
+  } else {
+    throw std::runtime_error("Collection 'refs' should be present");
   }
   //std::cout << "Fetching collection 'OneRelation'" << std::endl;
   auto& rels = store.get<ExampleWithOneRelationCollection>("OneRelation");
   if(rels.isValid()) {
     //std::cout << "Referenced object has an energy of " << (*rels)[0].cluster().energy() << std::endl;
     glob++;
+  } else {
+    throw std::runtime_error("Collection 'OneRelation' should be present");
   }
 
 //  std::cout << "Fetching collection 'WithVectorMember'" << std::endl;
@@ -137,6 +133,8 @@ void processEvent(podio::EventStore& store, bool verboser) {
 //      std::cout << "  Counter value " << (*c) << std::endl;
 //      glob++;
 //    }
+  } else {
+    throw std::runtime_error("Collection 'WithVectorMember' should be present");
   }
 
   auto& comps = store.get<ExampleWithComponentCollection>("Component");
@@ -148,23 +146,34 @@ void processEvent(podio::EventStore& store, bool verboser) {
   auto& nmspaces = store.get<ex::ExampleWithARelationCollection>("WithNamespaceRelation");
   auto& copies = store.get<ex::ExampleWithARelationCollection>("WithNamespaceRelationCopy");
   auto& cpytest = store.create<ex::ExampleWithARelationCollection>("TestConstCopy");
-  assert(nmspaces.isValid() && copies.isValid());
-  for (int j = 0; j < nmspaces.size(); j++) {
-    auto nmsp = nmspaces[j];
-    auto cpy = copies[j];
-    cpytest.push_back(nmsp.clone());
-    if (nmsp.ref().isAvailable()) {
-      assert(nmsp.ref().data().x == cpy.ref().data().x);
-      assert(nmsp.ref().data().y == cpy.ref().data().y);
-      assert(nmsp.number() == cpy.number());
-      assert(nmsp.ref().getObjectID() == cpy.ref().getObjectID());
+  if (nmspaces.isValid() && copies.isValid()) {
+    for (int j = 0; j < nmspaces.size(); j++) {
+      auto nmsp = nmspaces[j];
+      auto cpy = copies[j];
+      cpytest.push_back(nmsp.clone());
+      if (nmsp.ref().isAvailable()) {
+        if (nmsp.ref().data().x != cpy.ref().data().x || nmsp.ref().data().y != cpy.ref().data().y) {
+          throw std::runtime_error("Copied item has differing data in OneToOne referenced item.")
+        }
+        if (nmsp.number() != cpy.number()) {
+          throw std::runtime_error("Copied item has differing member.")
+        }
+        if (nmsp.ref().getObjectID() != cpy.ref().getObjectID()) {
+          throw std::runtime_error("Copied item has wrong OneToOne references.")
+        }
+      }
+      auto cpy_it = cpy.refs_begin();
+      for (auto it = nmsp.refs_begin(); it != nmsp.refs_end(); ++it, ++cpy_it) {
+        if (it->data().x != cpy_it->data().x || it->data().y != cpy_it->data().y) {
+          throw std::runtime_error("Copied item has differing data in OneToMany referenced item.")
+        }
+        if (it->getObjectID() != cpy_it->getObjectID()) {
+          throw std::runtime_error("Copied item has wrong OneToMany references.")
+        }
+      }
     }
-    auto cpy_it = cpy.refs_begin();
-    for (auto it = nmsp.refs_begin(); it != nmsp.refs_end(); ++it, ++cpy_it) {
-      assert(it->data().x == cpy_it->data().x);
-      assert(it->data().y == cpy_it->data().y);
-      assert(it->getObjectID() == cpy_it->getObjectID());
-    }
+  } else {
+    throw std::runtime_error("Collection 'WithNamespaceRelation' and 'WithNamespaceRelationCopy' should be present");
   }
 }
 

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -117,8 +117,6 @@ void processEvent(podio::EventStore& store, bool verboser) {
     }
     auto cpy_it = cpy.refs_begin();
     for (auto it = nmsp.refs_begin(); it != nmsp.refs_end(); ++it, ++cpy_it) {
-      std::cout << it->data().x << std::endl;
-      std::cout << cpy_it->data().x << std::endl;
       assert(it->data().x == cpy_it->data().x);
       assert(it->data().y == cpy_it->data().y);
       assert(it->getObjectID() == cpy_it->getObjectID());

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -155,6 +155,10 @@ void processEvent(podio::EventStore& store, bool verboser) {
         if (nmsp.ref().data().x != cpy.ref().data().x || nmsp.ref().data().y != cpy.ref().data().y) {
           throw std::runtime_error("Copied item has differing data in OneToOne referenced item.");
         }
+        // check direct accessors of POD sub members
+        if (nmsp.ref().x() != cpy.ref().x()) {
+          throw std::runtime_error("Getting wrong values when using direct accessors for sub members.");
+        }
         if (nmsp.number() != cpy.number()) {
           throw std::runtime_error("Copied item has differing member.");
         }

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -51,18 +51,62 @@ void processEvent(podio::EventStore& store, bool verboser) {
   auto& mcps =  store.get<ExampleMCCollection>("mcparticles");
   if( mcps.isValid() ){
 
+    // for( auto p : mcps ){
+    //   std::cout << " particle " << p.getObjectID().index << " daughters: " ;
+    //   for(auto it = p.daughters_begin(), end = p.daughters_end() ; it!=end ; ++it ){
+    // 	int dIndex = it->getObjectID().index ;
+    // 	std::cout << " " << dIndex ;
+    //   } 
+    //   std::cout << "  and parents: " ;
+    //   for(auto it = p.parents_begin(), end = p.parents_end() ; it!=end ; ++it ){
+    // 	std::cout << " " << it->getObjectID().index ;
+    //   }
+    //   std::cout << std::endl ;
+    // }
+
+    // check that we can retrieve the correct parent daughter relation
+    // set in write.cpp :
+
+    // particle 0 has particles 2,3,4 and 5 as daughters: 
+    auto p = mcps[0] ;
+
+    //-------- print relations for debugging:
     for( auto p : mcps ){
-      std::cout << " particle " << p.getObjectID().index << " daughters: " ;
+      std::cout << " particle " << p.getObjectID().index << " has daughters: " ;
       for(auto it = p.daughters_begin(), end = p.daughters_end() ; it!=end ; ++it ){
-	int dIndex = it->getObjectID().index ;
-	std::cout << " " << dIndex ;
-      } 
+	std::cout << " " << it->getObjectID().index ;
+      }
       std::cout << "  and parents: " ;
       for(auto it = p.parents_begin(), end = p.parents_end() ; it!=end ; ++it ){
 	std::cout << " " << it->getObjectID().index ;
       }
       std::cout << std::endl ;
     }
+
+    auto d0 = p.daughters(0) ;
+    auto d1 = p.daughters(1) ;
+    auto d2 = p.daughters(2) ;
+    auto d3 = p.daughters(3) ;
+    
+    if( ! ( d0 == mcps[2] ) )  throw std::runtime_error(" error: 1. daughter of particle 0 is not particle 2 " ) ;  
+    if( ! ( d1 == mcps[3] ) )  throw std::runtime_error(" error: 2. daughter of particle 0 is not particle 3 " ) ;  
+    if( ! ( d2 == mcps[4] ) )  throw std::runtime_error(" error: 3. daughter of particle 0 is not particle 4 " ) ;  
+    if( ! ( d3 == mcps[5] ) )  throw std::runtime_error(" error: 4. daughter of particle 0 is not particle 5 " ) ;  
+
+
+    // particle 3 has particles 6,7,8 and 9 as daughters: 
+    p = mcps[3] ;
+
+    d0 = p.daughters(0) ;
+    d1 = p.daughters(1) ;
+    d2 = p.daughters(2) ;
+    d3 = p.daughters(3) ;
+    
+    if( ! ( d0 == mcps[6] ) )  throw std::runtime_error(" error: 1. daughter of particle 3 is not particle 6 " ) ;  
+    if( ! ( d1 == mcps[7] ) )  throw std::runtime_error(" error: 2. daughter of particle 3 is not particle 7 " ) ;  
+    if( ! ( d2 == mcps[8] ) )  throw std::runtime_error(" error: 3. daughter of particle 3 is not particle 8 " ) ;  
+    if( ! ( d3 == mcps[9] ) )  throw std::runtime_error(" error: 4. daughter of particle 3 is not particle 9 " ) ;  
+
   }
 
 

--- a/tests/src/EventInfoCollection.cc
+++ b/tests/src/EventInfoCollection.cc
@@ -14,7 +14,7 @@ EventInfoCollection::~EventInfoCollection() {
   clear();
   if (m_data != nullptr) delete m_data;
   
-};
+}
 
 const EventInfo EventInfoCollection::operator[](unsigned int index) const {
   return EventInfo(m_entries[index]);

--- a/tests/src/EventInfoConst.cc
+++ b/tests/src/EventInfoConst.cc
@@ -42,6 +42,7 @@ ConstEventInfo::~ConstEventInfo(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  event number
   const int& ConstEventInfo::Number() const { return m_obj->data.Number; }
 
 

--- a/tests/src/EventInfoObj.cc
+++ b/tests/src/EventInfoObj.cc
@@ -13,7 +13,9 @@ EventInfoObj::EventInfoObj(const podio::ObjectID id, EventInfoData data) :
 EventInfoObj::EventInfoObj(const EventInfoObj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
     , data(other.data)
-{ }
+{
+
+}
 
 EventInfoObj::~EventInfoObj() {
   if (id.index == podio::ObjectID::untracked) {

--- a/tests/src/ExampleClusterCollection.cc
+++ b/tests/src/ExampleClusterCollection.cc
@@ -21,7 +21,7 @@ ExampleClusterCollection::~ExampleClusterCollection() {
   if (m_rel_Hits != nullptr) { delete m_rel_Hits; }
   if (m_rel_Clusters != nullptr) { delete m_rel_Clusters; }
 
-};
+}
 
 const ExampleCluster ExampleClusterCollection::operator[](unsigned int index) const {
   return ExampleCluster(m_entries[index]);

--- a/tests/src/ExampleClusterCollection.cc
+++ b/tests/src/ExampleClusterCollection.cc
@@ -84,7 +84,7 @@ void ExampleClusterCollection::prepareForWrite(){
   for(int i=0, size = m_data->size(); i != size; ++i){
    (*m_data)[i].Hits_begin=Hits_index;
    (*m_data)[i].Hits_end+=Hits_index;
-   Hits_index = (*m_data)[Hits_index].Hits_end;
+   Hits_index = (*m_data)[i].Hits_end;
    for(auto it : (*m_rel_Hits_tmp[i])) {
      if (it.getObjectID().index == podio::ObjectID::untracked)
        throw std::runtime_error("Trying to persistify untracked object");
@@ -93,7 +93,7 @@ void ExampleClusterCollection::prepareForWrite(){
    }
    (*m_data)[i].Clusters_begin=Clusters_index;
    (*m_data)[i].Clusters_end+=Clusters_index;
-   Clusters_index = (*m_data)[Clusters_index].Clusters_end;
+   Clusters_index = (*m_data)[i].Clusters_end;
    for(auto it : (*m_rel_Clusters_tmp[i])) {
      if (it.getObjectID().index == podio::ObjectID::untracked)
        throw std::runtime_error("Trying to persistify untracked object");

--- a/tests/src/ExampleClusterConst.cc
+++ b/tests/src/ExampleClusterConst.cc
@@ -42,6 +42,7 @@ ConstExampleCluster::~ConstExampleCluster(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  cluster energy
   const double& ConstExampleCluster::energy() const { return m_obj->data.energy; }
 
 std::vector<::ConstExampleHit>::const_iterator ConstExampleCluster::Hits_begin() const {

--- a/tests/src/ExampleClusterObj.cc
+++ b/tests/src/ExampleClusterObj.cc
@@ -14,7 +14,9 @@ ExampleClusterObj::ExampleClusterObj(const podio::ObjectID id, ExampleClusterDat
 ExampleClusterObj::ExampleClusterObj(const ExampleClusterObj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
     , data(other.data), m_Hits(new std::vector<ConstExampleHit>(*(other.m_Hits))), m_Clusters(new std::vector<ConstExampleCluster>(*(other.m_Clusters)))
-{ }
+{
+
+}
 
 ExampleClusterObj::~ExampleClusterObj() {
   if (id.index == podio::ObjectID::untracked) {

--- a/tests/src/ExampleForCyclicDependency1Collection.cc
+++ b/tests/src/ExampleForCyclicDependency1Collection.cc
@@ -18,7 +18,7 @@ ExampleForCyclicDependency1Collection::~ExampleForCyclicDependency1Collection() 
     for (auto& pointer : m_refCollections) { if (pointer != nullptr) delete pointer; }
   if (m_rel_ref != nullptr) { delete m_rel_ref; }
 
-};
+}
 
 const ExampleForCyclicDependency1 ExampleForCyclicDependency1Collection::operator[](unsigned int index) const {
   return ExampleForCyclicDependency1(m_entries[index]);

--- a/tests/src/ExampleForCyclicDependency1Const.cc
+++ b/tests/src/ExampleForCyclicDependency1Const.cc
@@ -39,6 +39,7 @@ ConstExampleForCyclicDependency1::~ConstExampleForCyclicDependency1(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  a ref
   const ::ConstExampleForCyclicDependency2 ConstExampleForCyclicDependency1::ref() const {
     if (m_obj->m_ref == nullptr) {
       return ::ConstExampleForCyclicDependency2(nullptr);

--- a/tests/src/ExampleForCyclicDependency1Obj.cc
+++ b/tests/src/ExampleForCyclicDependency1Obj.cc
@@ -14,7 +14,7 @@ ExampleForCyclicDependency1Obj::ExampleForCyclicDependency1Obj(const podio::Obje
 
 ExampleForCyclicDependency1Obj::ExampleForCyclicDependency1Obj(const ExampleForCyclicDependency1Obj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data)
+    , data(other.data), m_ref(new ConstExampleForCyclicDependency2(*(other.m_ref)))
 { }
 
 ExampleForCyclicDependency1Obj::~ExampleForCyclicDependency1Obj() {

--- a/tests/src/ExampleForCyclicDependency1Obj.cc
+++ b/tests/src/ExampleForCyclicDependency1Obj.cc
@@ -4,7 +4,7 @@
 
 
 ExampleForCyclicDependency1Obj::ExampleForCyclicDependency1Obj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(),m_ref(nullptr)
+    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(), m_ref(nullptr)
 
 { }
 
@@ -14,8 +14,13 @@ ExampleForCyclicDependency1Obj::ExampleForCyclicDependency1Obj(const podio::Obje
 
 ExampleForCyclicDependency1Obj::ExampleForCyclicDependency1Obj(const ExampleForCyclicDependency1Obj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data), m_ref(new ConstExampleForCyclicDependency2(*(other.m_ref)))
-{ }
+    , data(other.data), m_ref(nullptr)
+{
+  if (other.m_ref != nullptr) {
+     m_ref = new ConstExampleForCyclicDependency2(*(other.m_ref));
+  }
+
+}
 
 ExampleForCyclicDependency1Obj::~ExampleForCyclicDependency1Obj() {
   if (id.index == podio::ObjectID::untracked) {

--- a/tests/src/ExampleForCyclicDependency2Collection.cc
+++ b/tests/src/ExampleForCyclicDependency2Collection.cc
@@ -18,7 +18,7 @@ ExampleForCyclicDependency2Collection::~ExampleForCyclicDependency2Collection() 
     for (auto& pointer : m_refCollections) { if (pointer != nullptr) delete pointer; }
   if (m_rel_ref != nullptr) { delete m_rel_ref; }
 
-};
+}
 
 const ExampleForCyclicDependency2 ExampleForCyclicDependency2Collection::operator[](unsigned int index) const {
   return ExampleForCyclicDependency2(m_entries[index]);

--- a/tests/src/ExampleForCyclicDependency2Const.cc
+++ b/tests/src/ExampleForCyclicDependency2Const.cc
@@ -39,6 +39,7 @@ ConstExampleForCyclicDependency2::~ConstExampleForCyclicDependency2(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  a ref
   const ::ConstExampleForCyclicDependency1 ConstExampleForCyclicDependency2::ref() const {
     if (m_obj->m_ref == nullptr) {
       return ::ConstExampleForCyclicDependency1(nullptr);

--- a/tests/src/ExampleForCyclicDependency2Obj.cc
+++ b/tests/src/ExampleForCyclicDependency2Obj.cc
@@ -4,7 +4,7 @@
 
 
 ExampleForCyclicDependency2Obj::ExampleForCyclicDependency2Obj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(),m_ref(nullptr)
+    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(), m_ref(nullptr)
 
 { }
 
@@ -14,8 +14,13 @@ ExampleForCyclicDependency2Obj::ExampleForCyclicDependency2Obj(const podio::Obje
 
 ExampleForCyclicDependency2Obj::ExampleForCyclicDependency2Obj(const ExampleForCyclicDependency2Obj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data), m_ref(new ConstExampleForCyclicDependency1(*(other.m_ref)))
-{ }
+    , data(other.data), m_ref(nullptr)
+{
+  if (other.m_ref != nullptr) {
+     m_ref = new ConstExampleForCyclicDependency1(*(other.m_ref));
+  }
+
+}
 
 ExampleForCyclicDependency2Obj::~ExampleForCyclicDependency2Obj() {
   if (id.index == podio::ObjectID::untracked) {

--- a/tests/src/ExampleForCyclicDependency2Obj.cc
+++ b/tests/src/ExampleForCyclicDependency2Obj.cc
@@ -14,7 +14,7 @@ ExampleForCyclicDependency2Obj::ExampleForCyclicDependency2Obj(const podio::Obje
 
 ExampleForCyclicDependency2Obj::ExampleForCyclicDependency2Obj(const ExampleForCyclicDependency2Obj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data)
+    , data(other.data), m_ref(new ConstExampleForCyclicDependency1(*(other.m_ref)))
 { }
 
 ExampleForCyclicDependency2Obj::~ExampleForCyclicDependency2Obj() {

--- a/tests/src/ExampleHitCollection.cc
+++ b/tests/src/ExampleHitCollection.cc
@@ -14,7 +14,7 @@ ExampleHitCollection::~ExampleHitCollection() {
   clear();
   if (m_data != nullptr) delete m_data;
   
-};
+}
 
 const ExampleHit ExampleHitCollection::operator[](unsigned int index) const {
   return ExampleHit(m_entries[index]);

--- a/tests/src/ExampleHitConst.cc
+++ b/tests/src/ExampleHitConst.cc
@@ -42,9 +42,13 @@ ConstExampleHit::~ConstExampleHit(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  x-coordinate
   const double& ConstExampleHit::x() const { return m_obj->data.x; }
+  /// Access the  y-coordinate
   const double& ConstExampleHit::y() const { return m_obj->data.y; }
+  /// Access the  z-coordinate
   const double& ConstExampleHit::z() const { return m_obj->data.z; }
+  /// Access the  measured energy deposit
   const double& ConstExampleHit::energy() const { return m_obj->data.energy; }
 
 

--- a/tests/src/ExampleHitObj.cc
+++ b/tests/src/ExampleHitObj.cc
@@ -13,7 +13,9 @@ ExampleHitObj::ExampleHitObj(const podio::ObjectID id, ExampleHitData data) :
 ExampleHitObj::ExampleHitObj(const ExampleHitObj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
     , data(other.data)
-{ }
+{
+
+}
 
 ExampleHitObj::~ExampleHitObj() {
   if (id.index == podio::ObjectID::untracked) {

--- a/tests/src/ExampleMCCollection.cc
+++ b/tests/src/ExampleMCCollection.cc
@@ -21,7 +21,7 @@ ExampleMCCollection::~ExampleMCCollection() {
   if (m_rel_parents != nullptr) { delete m_rel_parents; }
   if (m_rel_daughters != nullptr) { delete m_rel_daughters; }
 
-};
+}
 
 const ExampleMC ExampleMCCollection::operator[](unsigned int index) const {
   return ExampleMC(m_entries[index]);

--- a/tests/src/ExampleMCCollection.cc
+++ b/tests/src/ExampleMCCollection.cc
@@ -84,7 +84,7 @@ void ExampleMCCollection::prepareForWrite(){
   for(int i=0, size = m_data->size(); i != size; ++i){
    (*m_data)[i].parents_begin=parents_index;
    (*m_data)[i].parents_end+=parents_index;
-   parents_index = (*m_data)[parents_index].parents_end;
+   parents_index = (*m_data)[i].parents_end;
    for(auto it : (*m_rel_parents_tmp[i])) {
      if (it.getObjectID().index == podio::ObjectID::untracked)
        throw std::runtime_error("Trying to persistify untracked object");
@@ -93,7 +93,7 @@ void ExampleMCCollection::prepareForWrite(){
    }
    (*m_data)[i].daughters_begin=daughters_index;
    (*m_data)[i].daughters_end+=daughters_index;
-   daughters_index = (*m_data)[daughters_index].daughters_end;
+   daughters_index = (*m_data)[i].daughters_end;
    for(auto it : (*m_rel_daughters_tmp[i])) {
      if (it.getObjectID().index == podio::ObjectID::untracked)
        throw std::runtime_error("Trying to persistify untracked object");

--- a/tests/src/ExampleMCConst.cc
+++ b/tests/src/ExampleMCConst.cc
@@ -42,7 +42,9 @@ ConstExampleMC::~ConstExampleMC(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  energy
   const double& ConstExampleMC::energy() const { return m_obj->data.energy; }
+  /// Access the  PDG code
   const int& ConstExampleMC::PDG() const { return m_obj->data.PDG; }
 
 std::vector<::ConstExampleMC>::const_iterator ConstExampleMC::parents_begin() const {

--- a/tests/src/ExampleMCObj.cc
+++ b/tests/src/ExampleMCObj.cc
@@ -15,7 +15,9 @@ ExampleMCObj::ExampleMCObj(const podio::ObjectID id, ExampleMCData data) :
 ExampleMCObj::ExampleMCObj(const ExampleMCObj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
     , data(other.data), m_parents(new std::vector<ConstExampleMC>(*(other.m_parents))), m_daughters(new std::vector<ConstExampleMC>(*(other.m_daughters)))
-{ }
+{
+
+}
 
 ExampleMCObj::~ExampleMCObj() {
   if (id.index == podio::ObjectID::untracked) {

--- a/tests/src/ExampleReferencingTypeCollection.cc
+++ b/tests/src/ExampleReferencingTypeCollection.cc
@@ -84,7 +84,7 @@ void ExampleReferencingTypeCollection::prepareForWrite(){
   for(int i=0, size = m_data->size(); i != size; ++i){
    (*m_data)[i].Clusters_begin=Clusters_index;
    (*m_data)[i].Clusters_end+=Clusters_index;
-   Clusters_index = (*m_data)[Clusters_index].Clusters_end;
+   Clusters_index = (*m_data)[i].Clusters_end;
    for(auto it : (*m_rel_Clusters_tmp[i])) {
      if (it.getObjectID().index == podio::ObjectID::untracked)
        throw std::runtime_error("Trying to persistify untracked object");
@@ -93,7 +93,7 @@ void ExampleReferencingTypeCollection::prepareForWrite(){
    }
    (*m_data)[i].Refs_begin=Refs_index;
    (*m_data)[i].Refs_end+=Refs_index;
-   Refs_index = (*m_data)[Refs_index].Refs_end;
+   Refs_index = (*m_data)[i].Refs_end;
    for(auto it : (*m_rel_Refs_tmp[i])) {
      if (it.getObjectID().index == podio::ObjectID::untracked)
        throw std::runtime_error("Trying to persistify untracked object");

--- a/tests/src/ExampleReferencingTypeCollection.cc
+++ b/tests/src/ExampleReferencingTypeCollection.cc
@@ -21,7 +21,7 @@ ExampleReferencingTypeCollection::~ExampleReferencingTypeCollection() {
   if (m_rel_Clusters != nullptr) { delete m_rel_Clusters; }
   if (m_rel_Refs != nullptr) { delete m_rel_Refs; }
 
-};
+}
 
 const ExampleReferencingType ExampleReferencingTypeCollection::operator[](unsigned int index) const {
   return ExampleReferencingType(m_entries[index]);

--- a/tests/src/ExampleReferencingTypeObj.cc
+++ b/tests/src/ExampleReferencingTypeObj.cc
@@ -14,7 +14,9 @@ ExampleReferencingTypeObj::ExampleReferencingTypeObj(const podio::ObjectID id, E
 ExampleReferencingTypeObj::ExampleReferencingTypeObj(const ExampleReferencingTypeObj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
     , data(other.data), m_Clusters(new std::vector<ConstExampleCluster>(*(other.m_Clusters))), m_Refs(new std::vector<ConstExampleReferencingType>(*(other.m_Refs)))
-{ }
+{
+
+}
 
 ExampleReferencingTypeObj::~ExampleReferencingTypeObj() {
   if (id.index == podio::ObjectID::untracked) {

--- a/tests/src/ExampleWithARelation.cc
+++ b/tests/src/ExampleWithARelation.cc
@@ -14,6 +14,10 @@ ExampleWithARelation::ExampleWithARelation() : m_obj(new ExampleWithARelationObj
  m_obj->acquire();
 }
 
+ExampleWithARelation::ExampleWithARelation(float number) : m_obj(new ExampleWithARelationObj()) {
+  m_obj->acquire();
+    m_obj->data.number = number;
+}
 
 
 ExampleWithARelation::ExampleWithARelation(const ExampleWithARelation& other) : m_obj(other.m_obj) {
@@ -41,12 +45,14 @@ ExampleWithARelation::~ExampleWithARelation(){
 
 ExampleWithARelation::operator ConstExampleWithARelation() const {return ConstExampleWithARelation(m_obj);}
 
+  const float& ExampleWithARelation::number() const { return m_obj->data.number; }
   const ex::ConstExampleWithNamespace ExampleWithARelation::ref() const {
     if (m_obj->m_ref == nullptr) {
       return ex::ConstExampleWithNamespace(nullptr);
     }
     return ex::ConstExampleWithNamespace(*(m_obj->m_ref));
   }
+void ExampleWithARelation::number(float value){ m_obj->data.number = value; }
 void ExampleWithARelation::ref(ex::ConstExampleWithNamespace value) {
   if (m_obj->m_ref != nullptr) delete m_obj->m_ref;
   m_obj->m_ref = new ConstExampleWithNamespace(value);

--- a/tests/src/ExampleWithARelationCollection.cc
+++ b/tests/src/ExampleWithARelationCollection.cc
@@ -21,7 +21,7 @@ ExampleWithARelationCollection::~ExampleWithARelationCollection() {
   if (m_rel_refs != nullptr) { delete m_rel_refs; }
   if (m_rel_ref != nullptr) { delete m_rel_ref; }
 
-};
+}
 
 const ExampleWithARelation ExampleWithARelationCollection::operator[](unsigned int index) const {
   return ExampleWithARelation(m_entries[index]);

--- a/tests/src/ExampleWithARelationCollection.cc
+++ b/tests/src/ExampleWithARelationCollection.cc
@@ -74,7 +74,7 @@ void ExampleWithARelationCollection::prepareForWrite(){
   for(int i=0, size = m_data->size(); i != size; ++i){
    (*m_data)[i].refs_begin=refs_index;
    (*m_data)[i].refs_end+=refs_index;
-   refs_index = (*m_data)[refs_index].refs_end;
+   refs_index = (*m_data)[i].refs_end;
    for(auto it : (*m_rel_refs_tmp[i])) {
      if (it.getObjectID().index == podio::ObjectID::untracked)
        throw std::runtime_error("Trying to persistify untracked object");

--- a/tests/src/ExampleWithARelationConst.cc
+++ b/tests/src/ExampleWithARelationConst.cc
@@ -43,7 +43,9 @@ ConstExampleWithARelation::~ConstExampleWithARelation(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  just a number
   const float& ConstExampleWithARelation::number() const { return m_obj->data.number; }
+  /// Access the  a ref in a namespace
   const ex::ConstExampleWithNamespace ConstExampleWithARelation::ref() const {
     if (m_obj->m_ref == nullptr) {
       return ex::ConstExampleWithNamespace(nullptr);

--- a/tests/src/ExampleWithARelationConst.cc
+++ b/tests/src/ExampleWithARelationConst.cc
@@ -14,6 +14,10 @@ ConstExampleWithARelation::ConstExampleWithARelation() : m_obj(new ExampleWithAR
  m_obj->acquire();
 }
 
+ConstExampleWithARelation::ConstExampleWithARelation(float number) : m_obj(new ExampleWithARelationObj()){
+ m_obj->acquire();
+   m_obj->data.number = number;
+}
 
 
 ConstExampleWithARelation::ConstExampleWithARelation(const ConstExampleWithARelation& other) : m_obj(other.m_obj) {
@@ -39,6 +43,7 @@ ConstExampleWithARelation::~ConstExampleWithARelation(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  const float& ConstExampleWithARelation::number() const { return m_obj->data.number; }
   const ex::ConstExampleWithNamespace ConstExampleWithARelation::ref() const {
     if (m_obj->m_ref == nullptr) {
       return ex::ConstExampleWithNamespace(nullptr);

--- a/tests/src/ExampleWithARelationObj.cc
+++ b/tests/src/ExampleWithARelationObj.cc
@@ -4,7 +4,7 @@
 
 namespace ex {
 ExampleWithARelationObj::ExampleWithARelationObj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(),m_ref(nullptr)
+    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(), m_ref(nullptr)
 , m_refs(new std::vector<::ex::ConstExampleWithNamespace>())
 { }
 
@@ -14,8 +14,13 @@ ExampleWithARelationObj::ExampleWithARelationObj(const podio::ObjectID id, Examp
 
 ExampleWithARelationObj::ExampleWithARelationObj(const ExampleWithARelationObj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data), m_ref(new ::ex::ConstExampleWithNamespace(*(other.m_ref))), m_refs(new std::vector<::ex::ConstExampleWithNamespace>(*(other.m_refs)))
-{ }
+    , data(other.data), m_ref(nullptr), m_refs(new std::vector<::ex::ConstExampleWithNamespace>(*(other.m_refs)))
+{
+  if (other.m_ref != nullptr) {
+     m_ref = new ::ex::ConstExampleWithNamespace(*(other.m_ref));
+  }
+
+}
 
 ExampleWithARelationObj::~ExampleWithARelationObj() {
   if (id.index == podio::ObjectID::untracked) {

--- a/tests/src/ExampleWithARelationObj.cc
+++ b/tests/src/ExampleWithARelationObj.cc
@@ -14,7 +14,7 @@ ExampleWithARelationObj::ExampleWithARelationObj(const podio::ObjectID id, Examp
 
 ExampleWithARelationObj::ExampleWithARelationObj(const ExampleWithARelationObj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data), m_refs(new std::vector<::ex::ConstExampleWithNamespace>(*(other.m_refs)))
+    , data(other.data), m_ref(new ::ex::ConstExampleWithNamespace(*(other.m_ref))), m_refs(new std::vector<::ex::ConstExampleWithNamespace>(*(other.m_refs)))
 { }
 
 ExampleWithARelationObj::~ExampleWithARelationObj() {

--- a/tests/src/ExampleWithComponent.cc
+++ b/tests/src/ExampleWithComponent.cc
@@ -45,9 +45,12 @@ ExampleWithComponent::~ExampleWithComponent(){
 ExampleWithComponent::operator ConstExampleWithComponent() const {return ConstExampleWithComponent(m_obj);}
 
   const NotSoSimpleStruct& ExampleWithComponent::component() const { return m_obj->data.component; }
+const SimpleStruct& ExampleWithComponent::data() const { return m_obj->data.component.data; }
 
   NotSoSimpleStruct& ExampleWithComponent::component() { return m_obj->data.component; }
 void ExampleWithComponent::component(class NotSoSimpleStruct value) { m_obj->data.component = value; }
+SimpleStruct& ExampleWithComponent::data() { return m_obj->data.component.data; }
+void ExampleWithComponent::data(class SimpleStruct value) { m_obj->data.component.data = value; }
 
 
 

--- a/tests/src/ExampleWithComponentCollection.cc
+++ b/tests/src/ExampleWithComponentCollection.cc
@@ -14,7 +14,7 @@ ExampleWithComponentCollection::~ExampleWithComponentCollection() {
   clear();
   if (m_data != nullptr) delete m_data;
   
-};
+}
 
 const ExampleWithComponent ExampleWithComponentCollection::operator[](unsigned int index) const {
   return ExampleWithComponent(m_entries[index]);

--- a/tests/src/ExampleWithComponentConst.cc
+++ b/tests/src/ExampleWithComponentConst.cc
@@ -42,6 +42,8 @@ ConstExampleWithComponent::~ConstExampleWithComponent(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  const SimpleStruct& ConstExampleWithComponent::data() const { return m_obj->data.component.data; }
+  /// Access the  a component
   const NotSoSimpleStruct& ConstExampleWithComponent::component() const { return m_obj->data.component; }
 
 

--- a/tests/src/ExampleWithComponentObj.cc
+++ b/tests/src/ExampleWithComponentObj.cc
@@ -13,7 +13,9 @@ ExampleWithComponentObj::ExampleWithComponentObj(const podio::ObjectID id, Examp
 ExampleWithComponentObj::ExampleWithComponentObj(const ExampleWithComponentObj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
     , data(other.data)
-{ }
+{
+
+}
 
 ExampleWithComponentObj::~ExampleWithComponentObj() {
   if (id.index == podio::ObjectID::untracked) {

--- a/tests/src/ExampleWithNamespace.cc
+++ b/tests/src/ExampleWithNamespace.cc
@@ -45,9 +45,13 @@ ExampleWithNamespace::~ExampleWithNamespace(){
 ExampleWithNamespace::operator ConstExampleWithNamespace() const {return ConstExampleWithNamespace(m_obj);}
 
   const ex2::NamespaceStruct& ExampleWithNamespace::data() const { return m_obj->data.data; }
+const int& ExampleWithNamespace::x() const { return m_obj->data.data.x; }
+const int& ExampleWithNamespace::y() const { return m_obj->data.data.y; }
 
   ex2::NamespaceStruct& ExampleWithNamespace::data() { return m_obj->data.data; }
 void ExampleWithNamespace::data(class ex2::NamespaceStruct value) { m_obj->data.data = value; }
+void ExampleWithNamespace::x(int value){ m_obj->data.data.x = value; }
+void ExampleWithNamespace::y(int value){ m_obj->data.data.y = value; }
 
 
 

--- a/tests/src/ExampleWithNamespaceCollection.cc
+++ b/tests/src/ExampleWithNamespaceCollection.cc
@@ -14,7 +14,7 @@ ExampleWithNamespaceCollection::~ExampleWithNamespaceCollection() {
   clear();
   if (m_data != nullptr) delete m_data;
   
-};
+}
 
 const ExampleWithNamespace ExampleWithNamespaceCollection::operator[](unsigned int index) const {
   return ExampleWithNamespace(m_entries[index]);

--- a/tests/src/ExampleWithNamespaceConst.cc
+++ b/tests/src/ExampleWithNamespaceConst.cc
@@ -42,6 +42,9 @@ ConstExampleWithNamespace::~ConstExampleWithNamespace(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  const int& ConstExampleWithNamespace::x() const { return m_obj->data.data.x; }
+  const int& ConstExampleWithNamespace::y() const { return m_obj->data.data.y; }
+  /// Access the  a component
   const ex2::NamespaceStruct& ConstExampleWithNamespace::data() const { return m_obj->data.data; }
 
 

--- a/tests/src/ExampleWithNamespaceObj.cc
+++ b/tests/src/ExampleWithNamespaceObj.cc
@@ -13,7 +13,9 @@ ExampleWithNamespaceObj::ExampleWithNamespaceObj(const podio::ObjectID id, Examp
 ExampleWithNamespaceObj::ExampleWithNamespaceObj(const ExampleWithNamespaceObj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
     , data(other.data)
-{ }
+{
+
+}
 
 ExampleWithNamespaceObj::~ExampleWithNamespaceObj() {
   if (id.index == podio::ObjectID::untracked) {

--- a/tests/src/ExampleWithOneRelationCollection.cc
+++ b/tests/src/ExampleWithOneRelationCollection.cc
@@ -18,7 +18,7 @@ ExampleWithOneRelationCollection::~ExampleWithOneRelationCollection() {
     for (auto& pointer : m_refCollections) { if (pointer != nullptr) delete pointer; }
   if (m_rel_cluster != nullptr) { delete m_rel_cluster; }
 
-};
+}
 
 const ExampleWithOneRelation ExampleWithOneRelationCollection::operator[](unsigned int index) const {
   return ExampleWithOneRelation(m_entries[index]);

--- a/tests/src/ExampleWithOneRelationConst.cc
+++ b/tests/src/ExampleWithOneRelationConst.cc
@@ -39,6 +39,7 @@ ConstExampleWithOneRelation::~ConstExampleWithOneRelation(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  a particular cluster
   const ::ConstExampleCluster ConstExampleWithOneRelation::cluster() const {
     if (m_obj->m_cluster == nullptr) {
       return ::ConstExampleCluster(nullptr);

--- a/tests/src/ExampleWithOneRelationObj.cc
+++ b/tests/src/ExampleWithOneRelationObj.cc
@@ -14,7 +14,7 @@ ExampleWithOneRelationObj::ExampleWithOneRelationObj(const podio::ObjectID id, E
 
 ExampleWithOneRelationObj::ExampleWithOneRelationObj(const ExampleWithOneRelationObj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data)
+    , data(other.data), m_cluster(new ConstExampleCluster(*(other.m_cluster)))
 { }
 
 ExampleWithOneRelationObj::~ExampleWithOneRelationObj() {

--- a/tests/src/ExampleWithOneRelationObj.cc
+++ b/tests/src/ExampleWithOneRelationObj.cc
@@ -4,7 +4,7 @@
 
 
 ExampleWithOneRelationObj::ExampleWithOneRelationObj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(),m_cluster(nullptr)
+    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(), m_cluster(nullptr)
 
 { }
 
@@ -14,8 +14,13 @@ ExampleWithOneRelationObj::ExampleWithOneRelationObj(const podio::ObjectID id, E
 
 ExampleWithOneRelationObj::ExampleWithOneRelationObj(const ExampleWithOneRelationObj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data), m_cluster(new ConstExampleCluster(*(other.m_cluster)))
-{ }
+    , data(other.data), m_cluster(nullptr)
+{
+  if (other.m_cluster != nullptr) {
+     m_cluster = new ConstExampleCluster(*(other.m_cluster));
+  }
+
+}
 
 ExampleWithOneRelationObj::~ExampleWithOneRelationObj() {
   if (id.index == podio::ObjectID::untracked) {

--- a/tests/src/ExampleWithStringCollection.cc
+++ b/tests/src/ExampleWithStringCollection.cc
@@ -14,7 +14,7 @@ ExampleWithStringCollection::~ExampleWithStringCollection() {
   clear();
   if (m_data != nullptr) delete m_data;
   
-};
+}
 
 const ExampleWithString ExampleWithStringCollection::operator[](unsigned int index) const {
   return ExampleWithString(m_entries[index]);

--- a/tests/src/ExampleWithStringConst.cc
+++ b/tests/src/ExampleWithStringConst.cc
@@ -42,6 +42,7 @@ ConstExampleWithString::~ConstExampleWithString(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  the string
   const std::string& ConstExampleWithString::theString() const { return m_obj->data.theString; }
 
 

--- a/tests/src/ExampleWithStringObj.cc
+++ b/tests/src/ExampleWithStringObj.cc
@@ -13,7 +13,9 @@ ExampleWithStringObj::ExampleWithStringObj(const podio::ObjectID id, ExampleWith
 ExampleWithStringObj::ExampleWithStringObj(const ExampleWithStringObj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
     , data(other.data)
-{ }
+{
+
+}
 
 ExampleWithStringObj::~ExampleWithStringObj() {
   if (id.index == podio::ObjectID::untracked) {

--- a/tests/src/ExampleWithVectorMemberCollection.cc
+++ b/tests/src/ExampleWithVectorMemberCollection.cc
@@ -14,7 +14,7 @@ ExampleWithVectorMemberCollection::~ExampleWithVectorMemberCollection() {
   clear();
   if (m_data != nullptr) delete m_data;
   
-};
+}
 
 const ExampleWithVectorMember ExampleWithVectorMemberCollection::operator[](unsigned int index) const {
   return ExampleWithVectorMember(m_entries[index]);

--- a/tests/src/ExampleWithVectorMemberObj.cc
+++ b/tests/src/ExampleWithVectorMemberObj.cc
@@ -13,7 +13,9 @@ ExampleWithVectorMemberObj::ExampleWithVectorMemberObj(const podio::ObjectID id,
 ExampleWithVectorMemberObj::ExampleWithVectorMemberObj(const ExampleWithVectorMemberObj& other) :
     ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
     , data(other.data), m_count(new std::vector<int>(*(other.m_count)))
-{ }
+{
+
+}
 
 ExampleWithVectorMemberObj::~ExampleWithVectorMemberObj() {
   if (id.index == podio::ObjectID::untracked) {

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -121,20 +121,20 @@ int main(){
     for( unsigned j=0,N=mcps.size();j<N;++j){
       p = mcps[j] ;
       for(auto it = p.daughters_begin(), end = p.daughters_end() ; it!=end ; ++it ){
-	int dIndex = it->getObjectID().index ;
-	d = mcps[ dIndex ] ;
-	d.addparents( p ) ;
+  int dIndex = it->getObjectID().index ;
+  d = mcps[ dIndex ] ;
+  d.addparents( p ) ;
       }
     }
     //-------- print relations for debugging:
     for( auto p : mcps ){
       std::cout << " particle " << p.getObjectID().index << " has daughters: " ;
       for(auto it = p.daughters_begin(), end = p.daughters_end() ; it!=end ; ++it ){
-	std::cout << " " << it->getObjectID().index ;
+  std::cout << " " << it->getObjectID().index ;
       }
       std::cout << "  and parents: " ;
       for(auto it = p.parents_begin(), end = p.parents_end() ; it!=end ; ++it ){
-	std::cout << " " << it->getObjectID().index ;
+  std::cout << " " << it->getObjectID().index ;
       }
       std::cout << std::endl ;
     }

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -37,6 +37,7 @@ int main(){
   auto& vecs       = store.create<ExampleWithVectorMemberCollection>("WithVectorMember");
   auto& namesps    = store.create<ex::ExampleWithNamespaceCollection>("WithNamespaceMember");
   auto& namesprels = store.create<ex::ExampleWithARelationCollection>("WithNamespaceRelation");
+  auto& cpytest    = store.create<ex::ExampleWithARelationCollection>("WithNamespaceRelationCopy");
   auto& strings    = store.create<ExampleWithStringCollection>("strings");
   writer.registerForWrite<EventInfoCollection>("info");
   writer.registerForWrite<ExampleMCCollection>("mcparticles");
@@ -49,6 +50,7 @@ int main(){
   writer.registerForWrite<ExampleWithVectorMemberCollection>("WithVectorMember");
   writer.registerForWrite<ex::ExampleWithNamespaceCollection>("WithNamespaceMember");
   writer.registerForWrite<ex::ExampleWithARelationCollection>("WithNamespaceRelation");
+  writer.registerForWrite<ex::ExampleWithARelationCollection>("WithNamespaceRelationCopy");
   writer.registerForWrite<ExampleWithStringCollection>("strings");
 
   unsigned nevents = 2000;
@@ -195,8 +197,12 @@ int main(){
     namesps.push_back(namesp);
 
     auto rel = ex::ExampleWithARelation();
+    rel.number(0.5);
     rel.ref(namesp);
+    rel.addrefs(namesp);
     namesprels.push_back(rel);
+
+    cpytest.push_back(rel.clone());
 
     auto string = ExampleWithString("SomeString");
     strings.push_back(string);

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -201,7 +201,7 @@ int main(){
         rel.ref(exWithNamesp);
         for (int k = 0; k < 5; k++) {
           auto namesp = ex::ExampleWithNamespace();
-          namesp.data().x = 3*k;
+          namesp.x(3*k);
           namesp.data().y = k;
           namesps.push_back(namesp);
           rel.addrefs(namesp);

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -190,19 +190,28 @@ int main(){
     vec.addcount(24);
     vecs.push_back(vec);
 
-
-    auto namesp = ex::ExampleWithNamespace();
-    namesp.data().x = 1;
-    namesp.data().y = i;
-    namesps.push_back(namesp);
-
-    auto rel = ex::ExampleWithARelation();
-    rel.number(0.5);
-    rel.ref(namesp);
-    rel.addrefs(namesp);
-    namesprels.push_back(rel);
-
-    cpytest.push_back(rel.clone());
+    for (int j = 0; j < 5; j++) {
+      auto rel = ex::ExampleWithARelation();
+      rel.number(0.5*j);
+      auto exWithNamesp = ex::ExampleWithNamespace();
+      exWithNamesp.data().x = i;
+      exWithNamesp.data().y = 1000*i;
+      namesps.push_back(exWithNamesp);
+      if (j != 3) { // also check for empty relations
+        rel.ref(exWithNamesp);
+        for (int k = 0; k < 5; k++) {
+          auto namesp = ex::ExampleWithNamespace();
+          namesp.data().x = 3*k;
+          namesp.data().y = k;
+          namesps.push_back(namesp);
+          rel.addrefs(namesp);
+        }
+      }
+      namesprels.push_back(rel);
+    }
+    for (int j = 0; j < namesprels.size(); ++j) {
+      cpytest.push_back(namesprels.at(j).clone());
+    }
 
     auto string = ExampleWithString("SomeString");
     strings.push_back(string);


### PR DESCRIPTION
Fixes:
- Fix issue when storing OneToManyRelations (also added tests)
- Fix initialisation of OneToOneRelations when copying (also added test)
- Improve generated comments:
  - Some were not doxygen-style comments (class descriptions)
  - The object classes now have the same documentation string as the data objects for the corresponding getters / setters

Additions:
- If a class owns a component, setters and getters will now be generated for the members of those components
  - This can be switched off with an option
  - We currently don't check if there are name-clashes
- Added options to yaml descriptions:
  - Switch between "get" and "set" prefixes (previously via command-line, I thought it would be useful ti have it be persistant for a given datamodel)
  - Switch for new component

