### PR TITLE
Change version, slight doxygen modifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 2.8)
 
 project(podio)
 set( podio_VERSION_MAJOR 0 )
-set( podio_VERSION_MINOR 1 )
-set( podio_VERSION_PATCH 0 )
+set( podio_VERSION_MINOR 4 )
+set( podio_VERSION_PATCH 1 )
 set( podio_VERSION "${podio_VERSION_MAJOR}.${podio_VERSION_MINOR}" )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(APPLE)
 endif(APPLE)
 
 #--- Declare options -----------------------------------------------------------
-option(podio_documentation "Whether or not to create doxygen doc target.")
+option(CREATE_DOC "Whether or not to create doxygen doc target.")
 
 #--- Declare ROOT dependency ---------------------------------------------------
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})

--- a/cmake/podioDoxygen.cmake
+++ b/cmake/podioDoxygen.cmake
@@ -1,8 +1,13 @@
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
+  # temporarily override the version for doxy generation (for nightly snapshots)
+  set(tmp ${podio_VERSION})
+  if(DOXYVERSION)
+    set(podio_VERSION ${DOXYVERSION})
+  endif()
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doc/Doxyfile.in
                  ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doc/doxy-boot.js.in 
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doc/doxy-boot.js.in
                  ${CMAKE_BINARY_DIR}/doxygen/html/doxy-boot.js)
   add_custom_target(doc
                     ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
@@ -10,4 +15,7 @@ if(DOXYGEN_FOUND)
                     COMMENT "Generating API documentation with Doxygen" VERBATIM)
 
   install( DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doxygen DESTINATION doxygen OPTIONAL)
+  # revert version to old value
+  set(podio_VERSION ${tmp})
+  unset(tmp)
 endif(DOXYGEN_FOUND)

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -38,7 +38,7 @@ PROJECT_NAME           = "PODIO"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         =
+PROJECT_NUMBER         = @podio_VERSION@
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -886,7 +886,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/doc/bootdoxyheader.html
+++ b/doc/bootdoxyheader.html
@@ -26,13 +26,10 @@
         <script type="text/javascript" src="$relpath^doxy-boot.js"></script>
     </head>
     <body>
-        <nav class="navbar navbar-default" role="navigation">
-            <div class="container">
-                <div class="navbar-header">
-                    <a class="navbar-brand">$projectname $projectnumber</a>
-                </div>
-            </div>
-        </nav>
+        <div class="container">
+            <h1>$projectname <small>$projectnumber</small></h1>
+        </div>
+        <hr>
         <div id="top"><!-- do not remove this div, it is closed by doxygen! -->
             <div class="content" id="content" style="margin-top:20px;">
                 <div class="container">


### PR DESCRIPTION
Updated the version to the last tag 0.4.1. Doxygen now uses `README.md` as title page. Use optional variable `DOXYVERSION` for doxygen, for nightlies building "snapshot" releases and doxygen pages.