### PR TITLE
Adding more ways to close file in python

### DIFF
--- a/include/podio/PythonEventStore.h
+++ b/include/podio/PythonEventStore.h
@@ -12,6 +12,9 @@ public:
   /// constructor from filename
   PythonEventStore(const char* filename);
 
+  /// destructor - closes file if still open
+  ~PythonEventStore();
+
   /// access a collection.
   podio::CollectionBase* get(const char* name);
 

--- a/python/EventStore.py
+++ b/python/EventStore.py
@@ -114,3 +114,7 @@ class EventStore(object):
         for nev, store in self.stores:
             nevts_all_files += nev
         return nevts_all_files
+
+    def close(self):
+        for store in self.stores:
+            store[1].close()

--- a/src/PythonEventStore.cc
+++ b/src/PythonEventStore.cc
@@ -7,6 +7,12 @@ podio::PythonEventStore::PythonEventStore(const char* name) :
   m_store.setReader(&m_reader);
 }
 
+podio::PythonEventStore::~PythonEventStore() {
+  if (m_reader.isValid()) {
+    m_reader.closeFile();
+  }
+}
+
 podio::CollectionBase* podio::PythonEventStore::get(const char* name) {
   const podio::CollectionBase* coll(nullptr);
   auto success = m_store.get(name, coll);


### PR DESCRIPTION
So far it was not possible to properly close files when done with them in python, unless one was using the `with`-idiom.