### PR TITLE
Further support for arrays

### DIFF
--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -132,6 +132,11 @@ class ClassGenerator(object):
                                                      % klass)
             elif "std::array" in klass:
                 datatype_dict["includes"].append("#include <array>")
+                array_type = klass.split("<")[1].split(",")[0]
+                if array_type not in self.buildin_types:
+                  if "::" in array_type:
+                        array_type = array_type.split("::")[1]
+                  datatype_dict["includes"].append("#include \"%s.h\"\n" % array_type)
             elif "vector" in klass:
                 datatype_dict["includes"].append("#include <vector>")
                 if is_data:  # avoid having warnings twice
@@ -253,6 +258,11 @@ class ClassGenerator(object):
             datatype["includes"].append('#include "%s.h"' %klass)
         elif "std::array" in klass:
           datatype["includes"].append("#include <array>")
+          array_type = klass.split("<")[1].split(",")[0]
+          if array_type not in self.buildin_types:
+            if "::" in array_type:
+                  array_type = array_type.split("::")[1]
+            datatype["includes"].append("#include \"%s.h\"\n" % array_type)
         else:
           raise Exception("'%s' declares a non-allowed many-relation to '%s'!" %(classname, klass))
 
@@ -720,6 +730,11 @@ class ClassGenerator(object):
               includes.append('#include "%s.h"\n' %(klassname))
           if "std::array" in klass:
               includes.append("#include <array>\n")
+              array_type = klass.split("<")[1].split(",")[0]
+              if array_type not in self.buildin_types:
+                if "::" in array_type:
+                      array_type = array_type.split("::")[1]
+                includes.append("#include \"%s.h\"\n" % array_type)
         else:
           # handle user provided extra code
           if klass.has_key("declaration"):

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -142,3 +142,4 @@ datatypes :
       - std::array<int, 4> anotherArray2 // array-member with space to test regex
       - std::array<int, 4> snail_case_array // snail case to test regex
       - std::array<int, 4> snail_case_Array3 // mixing things up for regex
+      - std::array<ex2::NamespaceStruct, 4> structArray // an array containing structs

--- a/tests/datamodel/ExampleWithArray.h
+++ b/tests/datamodel/ExampleWithArray.h
@@ -1,6 +1,8 @@
 #ifndef ExampleWithArray_H
 #define ExampleWithArray_H
 #include <array>
+#include "NamespaceStruct.h"
+
 #include "NotSoSimpleStruct.h"
 #include "ExampleWithArrayData.h"
 #include <vector>
@@ -32,7 +34,7 @@ public:
 
   /// default constructor
   ExampleWithArray();
-  ExampleWithArray(NotSoSimpleStruct arrayStruct,std::array<int, 4> myArray,std::array<int, 4> anotherArray2,std::array<int, 4> snail_case_array,std::array<int, 4> snail_case_Array3);
+  ExampleWithArray(NotSoSimpleStruct arrayStruct,std::array<int, 4> myArray,std::array<int, 4> anotherArray2,std::array<int, 4> snail_case_array,std::array<int, 4> snail_case_Array3,std::array<ex2::NamespaceStruct, 4> structArray);
 
   /// constructor from existing ExampleWithArrayObj
   ExampleWithArray(ExampleWithArrayObj* obj);
@@ -70,6 +72,10 @@ public:
   const std::array<int, 4>& snail_case_Array3() const;
   /// Access item i in the mixing things up for regex
   const int& snail_case_Array3(size_t i) const;
+  /// Access the an array containing structs
+  const std::array<ex2::NamespaceStruct, 4>& structArray() const;
+  /// Access item i in the an array containing structs
+  const ex2::NamespaceStruct& structArray(size_t i) const;
 
   /// Get reference to the  component that contains an array
   NotSoSimpleStruct& arrayStruct();
@@ -102,6 +108,12 @@ public:
 
   /// Set item i in mixing things up for regex
   void snail_case_Array3(size_t i, int value);
+
+  /// Set the an array containing structs
+  void structArray(std::array<ex2::NamespaceStruct, 4> value);
+
+  /// Set item i in an array containing structs
+  void structArray(size_t i, ex2::NamespaceStruct value);
 
 
 

--- a/tests/datamodel/ExampleWithArrayCollection.h
+++ b/tests/datamodel/ExampleWithArrayCollection.h
@@ -121,6 +121,8 @@ public:
   const std::array<std::array<int, 4>,arraysize> snail_case_array() const;
   template<size_t arraysize>
   const std::array<std::array<int, 4>,arraysize> snail_case_Array3() const;
+  template<size_t arraysize>
+  const std::array<std::array<ex2::NamespaceStruct, 4>,arraysize> structArray() const;
 
 
 private:
@@ -184,6 +186,15 @@ const std::array<class std::array<int, 4>,arraysize> ExampleWithArrayCollection:
   auto valid_size = std::min(arraysize,m_entries.size());
   for (unsigned i = 0; i<valid_size; ++i){
     tmp[i] = m_entries[i]->data.snail_case_Array3;
+ }
+ return tmp;
+}
+template<size_t arraysize>
+const std::array<class std::array<ex2::NamespaceStruct, 4>,arraysize> ExampleWithArrayCollection::structArray() const {
+  std::array<class std::array<ex2::NamespaceStruct, 4>,arraysize> tmp;
+  auto valid_size = std::min(arraysize,m_entries.size());
+  for (unsigned i = 0; i<valid_size; ++i){
+    tmp[i] = m_entries[i]->data.structArray;
  }
  return tmp;
 }

--- a/tests/datamodel/ExampleWithArrayConst.h
+++ b/tests/datamodel/ExampleWithArrayConst.h
@@ -1,6 +1,8 @@
 #ifndef ConstExampleWithArray_H
 #define ConstExampleWithArray_H
 #include <array>
+#include "NamespaceStruct.h"
+
 #include "NotSoSimpleStruct.h"
 #include "ExampleWithArrayData.h"
 #include <vector>
@@ -33,7 +35,7 @@ public:
 
   /// default constructor
   ConstExampleWithArray();
-  ConstExampleWithArray(NotSoSimpleStruct arrayStruct,std::array<int, 4> myArray,std::array<int, 4> anotherArray2,std::array<int, 4> snail_case_array,std::array<int, 4> snail_case_Array3);
+  ConstExampleWithArray(NotSoSimpleStruct arrayStruct,std::array<int, 4> myArray,std::array<int, 4> anotherArray2,std::array<int, 4> snail_case_array,std::array<int, 4> snail_case_Array3,std::array<ex2::NamespaceStruct, 4> structArray);
 
   /// constructor from existing ExampleWithArrayObj
   ConstExampleWithArray(ExampleWithArrayObj* obj);
@@ -69,6 +71,10 @@ public:
   const std::array<int, 4>& snail_case_Array3() const;
   /// Access item i in the mixing things up for regex
   const int& snail_case_Array3(size_t i) const;
+  /// Access the an array containing structs
+  const std::array<ex2::NamespaceStruct, 4>& structArray() const;
+  /// Access item i in the an array containing structs
+  const ex2::NamespaceStruct& structArray(size_t i) const;
 
 
 

--- a/tests/datamodel/ExampleWithArrayData.h
+++ b/tests/datamodel/ExampleWithArrayData.h
@@ -2,6 +2,8 @@
 #define ExampleWithArrayDATA_H
 
 #include <array>
+#include "NamespaceStruct.h"
+
 #include "NotSoSimpleStruct.h"
 
 
@@ -17,6 +19,7 @@ public:
   std::array<int, 4> anotherArray2;  ///<array-member with space to test regex
   std::array<int, 4> snail_case_array;  ///<snail case to test regex
   std::array<int, 4> snail_case_Array3;  ///<mixing things up for regex
+  std::array<ex2::NamespaceStruct, 4> structArray;  ///<an array containing structs
 };
 
 

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -153,6 +153,9 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
     if (array.arrayStruct().data.p.at(2) != 2*eventNum) {
       throw std::runtime_error("Array not properly set.");
     }
+    if (array.structArray(0).x != eventNum) {
+      throw std::runtime_error("Array of struct not properly set.");
+    }
   } else {
     throw std::runtime_error("Collection 'arrays' should be present");
   }

--- a/tests/src/ExampleWithArray.cc
+++ b/tests/src/ExampleWithArray.cc
@@ -13,9 +13,9 @@ ExampleWithArray::ExampleWithArray() : m_obj(new ExampleWithArrayObj()){
  m_obj->acquire();
 }
 
-ExampleWithArray::ExampleWithArray(NotSoSimpleStruct arrayStruct,std::array<int, 4> myArray,std::array<int, 4> anotherArray2,std::array<int, 4> snail_case_array,std::array<int, 4> snail_case_Array3) : m_obj(new ExampleWithArrayObj()) {
+ExampleWithArray::ExampleWithArray(NotSoSimpleStruct arrayStruct,std::array<int, 4> myArray,std::array<int, 4> anotherArray2,std::array<int, 4> snail_case_array,std::array<int, 4> snail_case_Array3,std::array<ex2::NamespaceStruct, 4> structArray) : m_obj(new ExampleWithArrayObj()) {
   m_obj->acquire();
-    m_obj->data.arrayStruct = arrayStruct;  m_obj->data.myArray = myArray;  m_obj->data.anotherArray2 = anotherArray2;  m_obj->data.snail_case_array = snail_case_array;  m_obj->data.snail_case_Array3 = snail_case_Array3;
+    m_obj->data.arrayStruct = arrayStruct;  m_obj->data.myArray = myArray;  m_obj->data.anotherArray2 = anotherArray2;  m_obj->data.snail_case_array = snail_case_array;  m_obj->data.snail_case_Array3 = snail_case_Array3;  m_obj->data.structArray = structArray;
 }
 
 
@@ -54,6 +54,8 @@ const SimpleStruct& ExampleWithArray::data() const { return m_obj->data.arrayStr
   const int& ExampleWithArray::snail_case_array(size_t i) const { return m_obj->data.snail_case_array.at(i); }
   const std::array<int, 4>& ExampleWithArray::snail_case_Array3() const { return m_obj->data.snail_case_Array3; }
   const int& ExampleWithArray::snail_case_Array3(size_t i) const { return m_obj->data.snail_case_Array3.at(i); }
+  const std::array<ex2::NamespaceStruct, 4>& ExampleWithArray::structArray() const { return m_obj->data.structArray; }
+  const ex2::NamespaceStruct& ExampleWithArray::structArray(size_t i) const { return m_obj->data.structArray.at(i); }
 
   NotSoSimpleStruct& ExampleWithArray::arrayStruct() { return m_obj->data.arrayStruct; }
 void ExampleWithArray::arrayStruct(class NotSoSimpleStruct value) { m_obj->data.arrayStruct = value; }
@@ -67,6 +69,8 @@ void ExampleWithArray::snail_case_array(std::array<int, 4> value) { m_obj->data.
 void ExampleWithArray::snail_case_array(size_t i, int value) { m_obj->data.snail_case_array.at(i) = value; }
 void ExampleWithArray::snail_case_Array3(std::array<int, 4> value) { m_obj->data.snail_case_Array3 = value; }
 void ExampleWithArray::snail_case_Array3(size_t i, int value) { m_obj->data.snail_case_Array3.at(i) = value; }
+void ExampleWithArray::structArray(std::array<ex2::NamespaceStruct, 4> value) { m_obj->data.structArray = value; }
+void ExampleWithArray::structArray(size_t i, ex2::NamespaceStruct value) { m_obj->data.structArray.at(i) = value; }
 
 
 

--- a/tests/src/ExampleWithArrayConst.cc
+++ b/tests/src/ExampleWithArrayConst.cc
@@ -13,9 +13,9 @@ ConstExampleWithArray::ConstExampleWithArray() : m_obj(new ExampleWithArrayObj()
  m_obj->acquire();
 }
 
-ConstExampleWithArray::ConstExampleWithArray(NotSoSimpleStruct arrayStruct,std::array<int, 4> myArray,std::array<int, 4> anotherArray2,std::array<int, 4> snail_case_array,std::array<int, 4> snail_case_Array3) : m_obj(new ExampleWithArrayObj()){
+ConstExampleWithArray::ConstExampleWithArray(NotSoSimpleStruct arrayStruct,std::array<int, 4> myArray,std::array<int, 4> anotherArray2,std::array<int, 4> snail_case_array,std::array<int, 4> snail_case_Array3,std::array<ex2::NamespaceStruct, 4> structArray) : m_obj(new ExampleWithArrayObj()){
  m_obj->acquire();
-   m_obj->data.arrayStruct = arrayStruct;  m_obj->data.myArray = myArray;  m_obj->data.anotherArray2 = anotherArray2;  m_obj->data.snail_case_array = snail_case_array;  m_obj->data.snail_case_Array3 = snail_case_Array3;
+   m_obj->data.arrayStruct = arrayStruct;  m_obj->data.myArray = myArray;  m_obj->data.anotherArray2 = anotherArray2;  m_obj->data.snail_case_array = snail_case_array;  m_obj->data.snail_case_Array3 = snail_case_Array3;  m_obj->data.structArray = structArray;
 }
 
 
@@ -61,6 +61,10 @@ ConstExampleWithArray::~ConstExampleWithArray(){
   const int& ConstExampleWithArray::snail_case_Array3(size_t i) const { return m_obj->data.snail_case_Array3.at(i); }
   /// Access the mixing things up for regex
   const std::array<int, 4>& ConstExampleWithArray::snail_case_Array3() const { return m_obj->data.snail_case_Array3; }
+  /// Access the an array containing structs
+  const ex2::NamespaceStruct& ConstExampleWithArray::structArray(size_t i) const { return m_obj->data.structArray.at(i); }
+  /// Access the an array containing structs
+  const std::array<ex2::NamespaceStruct, 4>& ConstExampleWithArray::structArray() const { return m_obj->data.structArray; }
 
 
 

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -221,13 +221,17 @@ int main(){
     strings.push_back(string);
 
     std::array<int, 4> arrayTest = {0, 0, 2, 3};
-    std::array<int, 4> arrayTest2 = {4, 4, 2*static_cast<int>(i)};
+    std::array<int, 4> arrayTest2 = {4, 4, 2 * static_cast<int>(i)};
     NotSoSimpleStruct a;
     a.data.p = arrayTest2;
-    auto array = ExampleWithArray(a, arrayTest, arrayTest, arrayTest, arrayTest);
+    ex2::NamespaceStruct nstruct;
+    nstruct.x = static_cast<int>(i);
+    std::array<ex2::NamespaceStruct, 4> structArrayTest = {nstruct, nstruct, nstruct, nstruct};
+    auto array = ExampleWithArray(a, arrayTest, arrayTest, arrayTest, arrayTest, structArrayTest);
     array.myArray(1, i);
     array.arrayStruct(a);
     arrays.push_back(array);
+
     writer.writeEvent();
     store.clearCollections();
   }


### PR DESCRIPTION
See also discussion in HEP-FCC/fcc-edm#31

Change proposed:

- Allow declaration of arrays of PODs

Fixes:

- Regex for arrays did not catch declaration of `std::array<SomeType, 4>` as it was only testing lower case