### PR TITLE
Clang-format, minor updates to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ To run the code generation script, do
     mkdir ../Tmp/src
     python ../python/podio_class_generator.py ../examples/datalayout.yaml ../Tmp data
 
+The generation script has the following additional options:
+
+- `--clangformat` (`-c`): Apply clang-format after file creation (uses [option `-style=file`](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) with llvm as backup style), needs clang-format in `$PATH`.
+- `--quiet` (`-q`): Suppress all print out to STDOUT
+- `--dryrun` (`-d`): Only run the generation logic and validate yaml, do not write files to disk
 
 ## Running tests
 After compilation and installation (!) you can run rudimentary tests with

--- a/doc/advanced_topics.md
+++ b/doc/advanced_topics.md
@@ -16,12 +16,14 @@ There is no interface a writing class has to fulfill. It only needs to take adva
 
 Before writing out a collection, the data need to be put into the proper structure. For this, the method `prepareForWrite` needs to be invoked. In the case of trivial POD members this results in a no-op. In case, the collection contains references to other collections, the pointers are being translated into `collID:objIndex` pairs. A serialization solution would - in principle - then look like this:
 
+```cpp
      collection->prepareForWrite();
      void* buffer = collection->getBufferAddress();
      auto refCollections = collection->referenceCollections();
-     ...
-        write buffer, collection ID, and refCollections
-     ...
+     // ...
+     //   write buffer, collection ID, and refCollections
+     // ...
+```
 
 ### Reading Back-End
 
@@ -29,25 +31,27 @@ There are two possibilities to implement a reading-back end. In case one uses th
 
 If not taking advantage of this implementation, the data reader or the event store have to implement the `ICollectionProvider` interface. Reading of a collection happens then similar to:
 
-    ... 
-      your creation of the collection and reading of the PODs from disk
-    ...
+```cpp
+    // ...
+    // your creation of the collection and reading of the PODs from disk
+    // ...
     collection->setBuffer(buffer);
     auto refCollections = collection->referenceCollections();
-    ...
-	  your filling of refCollections from disk
-    ... 
+    // ...
+    // your filling of refCollections from disk
+    // ...
     collection->setID( <collection ID read from disk> );
     collection->prepareAfterRead();
-    ...
-    collection->setReferences( &collectionProvider ); 
-    
-The strong assumption here is that all references are being followed up directly and no later on-demand reading is done. 
+    // ...
+    collection->setReferences( &collectionProvider );
+```
+
+The strong assumption here is that all references are being followed up directly and no later on-demand reading is done.
 
 ## Thread-safety
 
-PODIO was written with thread-safety in mind and avoids the usage of globals and statics. 
-However, a few assumptions about user code and use-patterns were made. 
+PODIO was written with thread-safety in mind and avoids the usage of globals and statics.
+However, a few assumptions about user code and use-patterns were made.
 The following lists the caveats of the library when it comes to parallelization.
 
 ### Changing user data
@@ -62,5 +66,5 @@ The example event store provided with PODIO is as of writing not thread-safe. Ne
 
 ## Implementing a transient Event Class
 
-PODIO contains one example `podio::EventStore` class. 
+PODIO contains one example `podio::EventStore` class.
 To implement your own transient event store, the only requirement is to set the collectionID of each collection to a unique ID on creation.

--- a/doc/datamodel_syntax.md
+++ b/doc/datamodel_syntax.md
@@ -6,24 +6,25 @@ From the user-provided data model description PODIO creates all the files necess
 
 ## Basic Concepts and Supported Features
 PODIO encourages the usage of composition, rather than inheritance.
-One of the reasons for doing so is the focus on efficiency friendly `plain-old-data`. 
-For this reason, PODIO does not support inheritance within the defined data model. 
+One of the reasons for doing so is the focus on efficiency friendly `plain-old-data`.
+For this reason, PODIO does not support inheritance within the defined data model.
 Instead, users can combine multiple `components` to build a to be used `datatype`.
 
 To allow the datatypes to be real PODs, the data stored within the data model are constrained to be
-POD-compatible data. Those are 
+POD-compatible data. Those are
 
  1. basic types like int, double, etc
  1. components built up from basic types or other components
  1. Fixed sized arrays of those types
- 
+
 In addition, PODIO supports the storage of one-to-one and one-to-many relations between objects.
-In the following the syntax for defining a given data model is explained. 
+In the following the syntax for defining a given data model is explained.
 A later section contains more details about the code being created from this.
 
 ## Definition of custom components
 A component is just a flat struct containing data. it can be defined via:
 
+```yaml
     components:
       # My example component
       MyComponent:
@@ -31,20 +32,23 @@ A component is just a flat struct containing data. it can be defined via:
         y : float
         z : float
         a : AnotherComponent
+```
 
 ## Definition of custom data classes
 Here an excerpt from "datamodel.yaml" for a simple class, just containing one member of the type `int`.
 
-
+```yaml
     datatypes :
       EventInfo :
         Description : "My first data type"
         Author : "It's me"
         Members :
         - int Number // event number
+```
 
 Using this definition, three classes will be created: `EventInfo`, `EventInfoData` and `EventInfoCollection`. These have the following signature:
 
+```cpp
     class EventInfoData {
       public:
         int Number;
@@ -57,27 +61,33 @@ Using this definition, three classes will be created: `EventInfo`, `EventInfoDat
         void Number(int);
       ...
     }
+```
 
 ### Defining members
 
 The definition of a member is done in the `Members` section in the form:
 
+```yaml
     Members:
       <type> <name> // <comment>
+```
 
 where `type` can be any buildin-type or a `component`.
 
 ### Definition of references between objects:
 There can be one-to-one-relations and one-to-many relations being stored in a particular class. This happens either in the `OneToOneRelations` or `OneToManyRelations` section of the data definition. The definition has again the form:
 
+```yaml
     OneToOneRelations:
       <type> <name> // <comment>
     OneToManyRelations:
       <type> <name> // <comment>
+```
 
 ### Explicit definition of methods
 In a few cases, it makes sense to add some more functionality to the created classes. Thus this library provides two ways of defining additional methods and code. Either by defining them inline or in external files. Extra code has to be provided separately for const and non-const additions.
 
+```yaml
     ExtraCode:
       declaration: <string>
       implementation : <string>
@@ -88,6 +98,7 @@ In a few cases, it makes sense to add some more functionality to the created cla
       implementation : <string>
       declarationFile: <string> (to be implemented!)
       implementationFile: <string> (to be implemented!)
+```
 
 The code being provided has to use the macro `{name}` in place of the concrete name of the class.
 
@@ -95,6 +106,7 @@ The code being provided has to use the macro `{name}` in place of the concrete n
 ## Global options
 Some customization of the generated code is possible through flags. These flags are listed in the section `options`:
 
+```yaml
     options:
       getSyntax: False
       exposePODMembers: True
@@ -108,11 +120,12 @@ Some customization of the generated code is possible through flags. These flags 
         Author: "Mr me"
         Members:
          - ExampleComponent comp // component from above
+```
 
 - `getSyntax`: steers the naming of get and set methods. If set to true, methods are prefixed with `get` and `set` following the capitalized member name, otherwise the member name is used for both.
 - `exposePODMembers`: whether get and set methods are also generated for members of a member-component. In the example corresponding methods would be generated to directly set / get `x` through `ExampleType`.
 
 
 
-  
-        
+
+

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -11,19 +11,23 @@ Every data created is either explicitly owned by collections or automatically ga
 
 Objects and collections can be created via factories, which ensure proper object ownership:
 
+```cpp
     auto& hits = store.create<HitCollection>("hits")
     auto hit1 = hits.create(1.4,2.4,3.7,4.2);  // init with values
     auto hit2 = hits.create(); // default-construct object
     hit2.energy(42.23);
+```
 
 In addition, individual objects can be created in the free. If they aren't attached to a collection, they are automatically garbage-collected:
 
+```cpp
     auto hit1 = Hit();
     auto hit2 = Hit();
     ...
     hits.push_back(hit1);
     ...
     <automatic deletion of hit2>
+```
 
 In this respect all objects behave like objects in Python.
 
@@ -31,6 +35,7 @@ In this respect all objects behave like objects in Python.
 
 The library supports the creation of one-to-many relations:
 
+```cpp
     auto& hits = store.create<HitCollection>("hits");
     auto hit1 = hits.create();
     auto hit2 = hits.create();
@@ -38,18 +43,23 @@ The library supports the creation of one-to-many relations:
     auto cluster = clusters.create();
     cluster.addHit(hit1);
     cluster.addHit(hit2);
+```
 
 The references can be accessed via iterators on the referencing objects
 
+```cpp
     for (auto i = cluster.Hits_begin(), \
          end = cluster.Hits_end(); i!=end; ++i){
       std::cout << i->energy() << std::endl;
     }
+```
 
 or via direct accessors
 
+```cpp
     auto size = cluster.Hits_size();
     auto hit  = cluster.Hits(<aNumber>);
+```
 
 If asking for an entry outside bounds, a std::out_of_range exception is thrown.
 
@@ -57,16 +67,19 @@ If asking for an entry outside bounds, a std::out_of_range exception is thrown.
 ### Looping through Collections
 Looping through collections is supported in two ways. Via iterators:
 
+```cpp
     for(auto i = hits.begin(), end = hits.end(); i != end; ++i) {
       std::cout << i->energy() << std::endl;
     }
+```
 
 and via direct object access:
 
+```cpp
     for(int i = 0, end = hits.size(), i != end, ++i){
       std::cout << hit[i].energy() << std::endl;
     }
-
+```
 
 ### Support for Notebook-Pattern
 
@@ -74,8 +87,10 @@ The `notebook pattern` uses the assumption that it is better to create a small
 copy of only the data that are needed for a particular calculation. This
 pattern is supported by providing access like
 
+```cpp
     auto x_array = hits.x<10>(); // returning values of
     auto y_array = hits.y<10>(); // the first 10 elements
+```
 
 The resulting `std::array` can then be used in (auto-)vectorizable code.
 If less objects than requested are contained in the collection, the remaining entries are default initialized.
@@ -84,6 +99,7 @@ If less objects than requested are contained in the collection, the remaining en
 
 The event store contained in the package is for *educational* purposes and kept very minimal. It has two main methods:
 
+```cpp
     /// create a new collection
     template<typename T>
     T& create(const std::string& name);
@@ -91,6 +107,7 @@ The event store contained in the package is for *educational* purposes and kept 
     /// access a collection.
     template<typename T>
     const T& get(const std::string& name);
+```
 
 Please note that a `put` method for collections is not foreseen.
 
@@ -98,8 +115,10 @@ Please note that a `put` method for collections is not foreseen.
 
 Collections can be retrieved explicitly:
 
+```cpp
     auto& hits = store.get<HitCollection>("hits");
     if (hits.isValid()) { ... }
+```
 
 Or implicitly when following an object reference. In both cases the access to data that has been retrieved is `const`.
 
@@ -107,9 +126,11 @@ Or implicitly when following an object reference. In both cases the access to da
 
 The class `EventStore` provides all the necessary (read) access to event files. It can be used as follows:
 
+```python
     from EventStore import EventStore
     store = EventStore(<list of files>)
     for event in store:
       hits = store.get("hits")
       for hit in hits:
-        ...
+        # ...
+```

--- a/init.sh
+++ b/init.sh
@@ -9,10 +9,9 @@ fi
 if [[ "$unamestr" == 'Linux' ]]; then
     platform='Linux'
     if [[ -d /cvmfs/sft.cern.ch/lcg ]]; then
-	#should check domain to make sure we're at CERN
-	#or is this software available somewhere in Lyon?
-    source /cvmfs/sft.cern.ch/lcg/views/LCG_88/x86_64-slc6-gcc49-opt/setup.sh
-	echo cmake and root taken from /cvmfs/sft.cern.ch/lcg
+        source /cvmfs/sft.cern.ch/lcg/views/LCG_88/x86_64-slc6-gcc49-opt/setup.sh
+        echo cmake and root taken from /cvmfs/sft.cern.ch/lcg
+        export PATH=$PATH:/cvmfs/sft.cern.ch/lcg/contrib/llvm/3.9.0/x86_64-slc6-gcc49-opt/bin
     fi
     export LD_LIBRARY_PATH=$PODIO/tests:$PODIO/lib:$PODIO/tests:$LD_LIBRARY_PATH
 elif [[ "$unamestr" == 'Darwin' ]]; then

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -2,6 +2,7 @@
 import os
 import string
 import pickle
+import subprocess
 from podio_config_reader import PodioConfigReader, ClassDefinitionValidator
 from podio_templates import declarations, implementations
 thisdir = os.path.dirname(os.path.abspath(__file__))
@@ -38,6 +39,17 @@ class ClassGenerator(object):
         self.warnings = []
         self.component_members = {}
         self.dryrun = dryrun
+
+    def apply_clang_format(self, clangformat):
+        try:
+            cformat_exe = subprocess.check_output(['which', 'clang-format']).strip()
+        except subprocess.CalledProcessError:
+            print "ERROR: Cannot find clang-format executable"
+            print "       Please make sure it is in the PATH."
+            self.clang_format = []
+            return
+        self.clang_format = [cformat_exe, "-i",  "-style=file", "-fallback-style=llvm"]
+
 
     def process(self):
         self.reader.read()
@@ -870,6 +882,7 @@ class ClassGenerator(object):
         fullname = os.path.join(self.install_dir,"src",name)
       if not self.dryrun:
         open(fullname, "w").write(content)
+        subprocess.call(self.clang_format + [fullname])
 
     def evaluate_template(self, filename, substitutions):
         """ reads in a given template, evaluates it
@@ -932,6 +945,9 @@ if __name__ == "__main__":
   parser.add_option("-d", "--dryrun",
                     action="store_true", dest="dryrun", default=False,
                     help="Do not actually write datamodel files")
+  parser.add_option("-c", "--clangformat", dest="clangformat",
+                    action="store_true", default=False,
+                    help="Apply clang-format when generating code (with -style=file)")
   (options, args) = parser.parse_args()
 
   if len(args) != 3:
@@ -942,13 +958,15 @@ if __name__ == "__main__":
   project = args[2]
   directory = os.path.join( install_path ,"src" )
   if not os.path.exists( directory ):
-    os.makedirs(directory)
+      os.makedirs(directory)
   directory = os.path.join( install_path , project )
 
   if not os.path.exists( directory ):
-    os.makedirs(directory)
+      os.makedirs(directory)
 
   gen = ClassGenerator(args[0], args[1], args[2], verbose=options.verbose, dryrun=options.dryrun)
+  if options.clangformat:
+      gen.apply_clang_format(options.clangformat)
   gen.process()
   for warning in gen.warnings:
       print warning

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -882,7 +882,8 @@ class ClassGenerator(object):
         fullname = os.path.join(self.install_dir,"src",name)
       if not self.dryrun:
         open(fullname, "w").write(content)
-        subprocess.call(self.clang_format + [fullname])
+        if self.clang_format:
+          subprocess.call(self.clang_format + [fullname])
 
     def evaluate_template(self, filename, substitutions):
         """ reads in a given template, evaluates it

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,7 +39,7 @@ endforeach( sourcefile ${executables} )
 
 
 #--- Adding tests --------------------------------------------------------------
-add_test(NAME generate-edm COMMAND python $ENV{PODIO}/python/podio_class_generator.py tests/datalayout.yaml tests datamodel --dryrun
+add_test(NAME generate-edm COMMAND python $ENV{PODIO}/python/podio_class_generator.py tests/datalayout.yaml tests datamodel --dryrun --clangformat
          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 set_property(TEST generate-edm PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/tests:$ENV{LD_LIBRARY_PATH})
 


### PR DESCRIPTION
Changes proposed:

- Adding option to run clang-format after code generation
- Documented options of the class generator in README
- Cosmetic fix: Highlight syntax correctly in `doc/*.md`