### PR TITLE
Add override statements

### DIFF
--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -48,7 +48,7 @@ namespace podio {
     bool get(const std::string& name, const T*& collection);
 
     /// access a collection by ID. returns true if successful
-    bool get(int id, CollectionBase*& coll) const;
+    bool get(int id, CollectionBase*& coll) const override final;
 
     /// access a collection by name
     /// returns a collection w/ setting isValid to true if successful

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -46,7 +46,7 @@ class ROOTReader : public IReader {
     bool getCollection(const std::string& name, T*& collection);
 
     /// Read CollectionIDTable from ROOT file
-    CollectionIDTable* getCollectionIDTable() {return m_table;}
+    CollectionIDTable* getCollectionIDTable() override final {return m_table;}
 
     /// Returns number of entries in the TTree
     unsigned getEntries() const;
@@ -58,14 +58,14 @@ class ROOTReader : public IReader {
     void goToEvent(unsigned evnum);
 
     /// Check if TFile is valid
-    virtual bool isValid() const;
+    virtual bool isValid() const override final;
 
   private:
 
     void readCollectionIDTable();
 
     /// Implementation for collection reading
-    CollectionBase* readCollection(const std::string& name);
+    CollectionBase* readCollection(const std::string& name) override final;
 
   private:
     typedef std::pair<CollectionBase*, std::string> Input;

--- a/templates/Collection.h.template
+++ b/templates/Collection.h.template
@@ -56,7 +56,7 @@ public:
 //  ${name}Collection(${name}Vector* data, int collectionID);
   ~${name}Collection();
 
-  void clear();
+  void clear() override final;
   /// Append a new object to the collection, and return this object.
   ${name} create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(Const${name} object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void* address) override final;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override final { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override final {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](${name}Obj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override final {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override final { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<${name}Data>* _getBuffer() { return m_data;};

--- a/tests/datamodel/EventInfoCollection.h
+++ b/tests/datamodel/EventInfoCollection.h
@@ -56,7 +56,7 @@ public:
 //  EventInfoCollection(EventInfoVector* data, int collectionID);
   ~EventInfoCollection();
 
-  void clear();
+  void clear() override;
   /// Append a new object to the collection, and return this object.
   EventInfo create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(ConstEventInfo object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override;
+  void prepareAfterRead() override;
+  void setBuffer(void* address) override;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](EventInfoObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<EventInfoData>* _getBuffer() { return m_data;};

--- a/tests/datamodel/ExampleClusterCollection.h
+++ b/tests/datamodel/ExampleClusterCollection.h
@@ -56,7 +56,7 @@ public:
 //  ExampleClusterCollection(ExampleClusterVector* data, int collectionID);
   ~ExampleClusterCollection();
 
-  void clear();
+  void clear() override;
   /// Append a new object to the collection, and return this object.
   ExampleCluster create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(ConstExampleCluster object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override;
+  void prepareAfterRead() override;
+  void setBuffer(void* address) override;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](ExampleClusterObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<ExampleClusterData>* _getBuffer() { return m_data;};

--- a/tests/datamodel/ExampleForCyclicDependency1Collection.h
+++ b/tests/datamodel/ExampleForCyclicDependency1Collection.h
@@ -56,7 +56,7 @@ public:
 //  ExampleForCyclicDependency1Collection(ExampleForCyclicDependency1Vector* data, int collectionID);
   ~ExampleForCyclicDependency1Collection();
 
-  void clear();
+  void clear() override;
   /// Append a new object to the collection, and return this object.
   ExampleForCyclicDependency1 create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(ConstExampleForCyclicDependency1 object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override;
+  void prepareAfterRead() override;
+  void setBuffer(void* address) override;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](ExampleForCyclicDependency1Obj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<ExampleForCyclicDependency1Data>* _getBuffer() { return m_data;};

--- a/tests/datamodel/ExampleForCyclicDependency2Collection.h
+++ b/tests/datamodel/ExampleForCyclicDependency2Collection.h
@@ -56,7 +56,7 @@ public:
 //  ExampleForCyclicDependency2Collection(ExampleForCyclicDependency2Vector* data, int collectionID);
   ~ExampleForCyclicDependency2Collection();
 
-  void clear();
+  void clear() override;
   /// Append a new object to the collection, and return this object.
   ExampleForCyclicDependency2 create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(ConstExampleForCyclicDependency2 object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override;
+  void prepareAfterRead() override;
+  void setBuffer(void* address) override;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](ExampleForCyclicDependency2Obj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<ExampleForCyclicDependency2Data>* _getBuffer() { return m_data;};

--- a/tests/datamodel/ExampleHitCollection.h
+++ b/tests/datamodel/ExampleHitCollection.h
@@ -56,7 +56,7 @@ public:
 //  ExampleHitCollection(ExampleHitVector* data, int collectionID);
   ~ExampleHitCollection();
 
-  void clear();
+  void clear() override;
   /// Append a new object to the collection, and return this object.
   ExampleHit create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(ConstExampleHit object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override;
+  void prepareAfterRead() override;
+  void setBuffer(void* address) override;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](ExampleHitObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<ExampleHitData>* _getBuffer() { return m_data;};

--- a/tests/datamodel/ExampleMCCollection.h
+++ b/tests/datamodel/ExampleMCCollection.h
@@ -56,7 +56,7 @@ public:
 //  ExampleMCCollection(ExampleMCVector* data, int collectionID);
   ~ExampleMCCollection();
 
-  void clear();
+  void clear() override;
   /// Append a new object to the collection, and return this object.
   ExampleMC create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(ConstExampleMC object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override;
+  void prepareAfterRead() override;
+  void setBuffer(void* address) override;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](ExampleMCObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<ExampleMCData>* _getBuffer() { return m_data;};

--- a/tests/datamodel/ExampleReferencingTypeCollection.h
+++ b/tests/datamodel/ExampleReferencingTypeCollection.h
@@ -56,7 +56,7 @@ public:
 //  ExampleReferencingTypeCollection(ExampleReferencingTypeVector* data, int collectionID);
   ~ExampleReferencingTypeCollection();
 
-  void clear();
+  void clear() override;
   /// Append a new object to the collection, and return this object.
   ExampleReferencingType create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(ConstExampleReferencingType object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override;
+  void prepareAfterRead() override;
+  void setBuffer(void* address) override;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](ExampleReferencingTypeObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<ExampleReferencingTypeData>* _getBuffer() { return m_data;};

--- a/tests/datamodel/ExampleWithARelationCollection.h
+++ b/tests/datamodel/ExampleWithARelationCollection.h
@@ -56,7 +56,7 @@ public:
 //  ExampleWithARelationCollection(ExampleWithARelationVector* data, int collectionID);
   ~ExampleWithARelationCollection();
 
-  void clear();
+  void clear() override;
   /// Append a new object to the collection, and return this object.
   ExampleWithARelation create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(ConstExampleWithARelation object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override;
+  void prepareAfterRead() override;
+  void setBuffer(void* address) override;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](ExampleWithARelationObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<ExampleWithARelationData>* _getBuffer() { return m_data;};

--- a/tests/datamodel/ExampleWithArrayCollection.h
+++ b/tests/datamodel/ExampleWithArrayCollection.h
@@ -56,7 +56,7 @@ public:
 //  ExampleWithArrayCollection(ExampleWithArrayVector* data, int collectionID);
   ~ExampleWithArrayCollection();
 
-  void clear();
+  void clear() override;
   /// Append a new object to the collection, and return this object.
   ExampleWithArray create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(ConstExampleWithArray object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override;
+  void prepareAfterRead() override;
+  void setBuffer(void* address) override;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](ExampleWithArrayObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<ExampleWithArrayData>* _getBuffer() { return m_data;};

--- a/tests/datamodel/ExampleWithComponentCollection.h
+++ b/tests/datamodel/ExampleWithComponentCollection.h
@@ -56,7 +56,7 @@ public:
 //  ExampleWithComponentCollection(ExampleWithComponentVector* data, int collectionID);
   ~ExampleWithComponentCollection();
 
-  void clear();
+  void clear() override;
   /// Append a new object to the collection, and return this object.
   ExampleWithComponent create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(ConstExampleWithComponent object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override;
+  void prepareAfterRead() override;
+  void setBuffer(void* address) override;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](ExampleWithComponentObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<ExampleWithComponentData>* _getBuffer() { return m_data;};

--- a/tests/datamodel/ExampleWithNamespaceCollection.h
+++ b/tests/datamodel/ExampleWithNamespaceCollection.h
@@ -56,7 +56,7 @@ public:
 //  ExampleWithNamespaceCollection(ExampleWithNamespaceVector* data, int collectionID);
   ~ExampleWithNamespaceCollection();
 
-  void clear();
+  void clear() override;
   /// Append a new object to the collection, and return this object.
   ExampleWithNamespace create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(ConstExampleWithNamespace object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override;
+  void prepareAfterRead() override;
+  void setBuffer(void* address) override;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](ExampleWithNamespaceObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<ExampleWithNamespaceData>* _getBuffer() { return m_data;};

--- a/tests/datamodel/ExampleWithOneRelationCollection.h
+++ b/tests/datamodel/ExampleWithOneRelationCollection.h
@@ -56,7 +56,7 @@ public:
 //  ExampleWithOneRelationCollection(ExampleWithOneRelationVector* data, int collectionID);
   ~ExampleWithOneRelationCollection();
 
-  void clear();
+  void clear() override;
   /// Append a new object to the collection, and return this object.
   ExampleWithOneRelation create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(ConstExampleWithOneRelation object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override;
+  void prepareAfterRead() override;
+  void setBuffer(void* address) override;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](ExampleWithOneRelationObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<ExampleWithOneRelationData>* _getBuffer() { return m_data;};

--- a/tests/datamodel/ExampleWithStringCollection.h
+++ b/tests/datamodel/ExampleWithStringCollection.h
@@ -56,7 +56,7 @@ public:
 //  ExampleWithStringCollection(ExampleWithStringVector* data, int collectionID);
   ~ExampleWithStringCollection();
 
-  void clear();
+  void clear() override;
   /// Append a new object to the collection, and return this object.
   ExampleWithString create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(ConstExampleWithString object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override;
+  void prepareAfterRead() override;
+  void setBuffer(void* address) override;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](ExampleWithStringObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<ExampleWithStringData>* _getBuffer() { return m_data;};

--- a/tests/datamodel/ExampleWithVectorMemberCollection.h
+++ b/tests/datamodel/ExampleWithVectorMemberCollection.h
@@ -56,7 +56,7 @@ public:
 //  ExampleWithVectorMemberCollection(ExampleWithVectorMemberVector* data, int collectionID);
   ~ExampleWithVectorMemberCollection();
 
-  void clear();
+  void clear() override;
   /// Append a new object to the collection, and return this object.
   ExampleWithVectorMember create();
 
@@ -79,21 +79,21 @@ public:
   /// Append object to the collection
   void push_back(ConstExampleWithVectorMember object);
 
-  void prepareForWrite();
-  void prepareAfterRead();
-  void setBuffer(void* address);
-  bool setReferences(const podio::ICollectionProvider* collectionProvider);
+  void prepareForWrite() override;
+  void prepareAfterRead() override;
+  void setBuffer(void* address) override;
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
-  podio::CollRefCollection* referenceCollections() { return &m_refCollections;};
+  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
 
-  void setID(unsigned ID){
+  void setID(unsigned ID) override {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
                  [ID](ExampleWithVectorMemberObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
     );
   };
 
-  bool isValid() const {
+  bool isValid() const override {
     return m_isValid;
   }
 
@@ -106,7 +106,7 @@ public:
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() { return (void*)&m_data;};
+  void* getBufferAddress() override { return (void*)&m_data;};
 
   /// returns the pointer to the data buffer
   std::vector<ExampleWithVectorMemberData>* _getBuffer() { return m_data;};


### PR DESCRIPTION
With the proposed change in PR HEP-FCC/FCCSW#209, many warnings are issued due to missing override statements in the data model. This PR adds the statements where appropriate.