### PR TITLE
can now get the name of the current file 

### DIFF
--- a/python/EventStore.py
+++ b/python/EventStore.py
@@ -43,6 +43,7 @@ class EventStore(object):
         self.current_store = None
         for fname in self.files:
             store = podio.PythonEventStore(fname)
+            store.name = fname
             if self.current_store is None:
                 self.current_store = store
             self.stores.append((store.getEntries(), store))
@@ -77,6 +78,13 @@ class EventStore(object):
     #     else:
     #         return None
 
+    def current_filename(self):
+        '''Returns the name of the current file.'''
+        if self.current_store is None:
+            return None
+        else:
+            return self.current_store.fname
+    
     def __enter__(self):
         return self
 


### PR DESCRIPTION
With this change, in case an exception occurs at a given event when processing a chain of files, heppy is now able to report the file in which the exception occurs, as well as the event number. Mandatory to debug rare problems.