### PR TITLE
Use TChain in the ROOTReader

### DIFF
--- a/include/podio/PythonEventStore.h
+++ b/include/podio/PythonEventStore.h
@@ -28,7 +28,7 @@ public:
   bool isZombie() const {return m_isZombie;}
   
   bool isValid() const {return m_reader.isValid();}
-  void close() {m_reader.closeFile();}
+  void close() {m_reader.closeFiles();}
 
   /// list available collections
   const std::vector<std::string>& getCollectionNames() const;

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -5,22 +5,17 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <iostream>
 
 // forward declarations
 class TClass;
 class TFile;
 class TTree;
+class TChain;
 
-#include <iostream>
 
 #include "podio/ICollectionProvider.h"
 #include "podio/IReader.h"
-/*
-
-This class has the function to read available data from disk
-and to prepare collections and buffers.
-
-*/
 
 
 namespace podio {
@@ -30,13 +25,17 @@ class CollectionBase;
 class Registry;
 class CollectionIDTable;
 
+/**
+This class has the function to read available data from disk
+and to prepare collections and buffers.
+**/
 class ROOTReader : public IReader {
   friend EventStore;
   public:
     ROOTReader() : m_eventNumber(0) {}
     ~ROOTReader();
-    void openFile(const std::string& filename);
-    void closeFile();
+    void openFiles(const std::vector<std::string>& filenames);
+    void closeFiles();
 
     /// Read all collections requested
     void readEvent();
@@ -62,8 +61,6 @@ class ROOTReader : public IReader {
 
   private:
 
-    void readCollectionIDTable();
-
     /// Implementation for collection reading
     CollectionBase* readCollection(const std::string& name) override final;
 
@@ -72,8 +69,7 @@ class ROOTReader : public IReader {
     std::vector<Input> m_inputs;
     std::map<std::string, std::pair<TClass*,TClass*> > m_storedClasses;
     CollectionIDTable* m_table;
-    TFile* m_file;
-    TTree* m_eventTree;
+    TChain* m_chain;
     unsigned m_eventNumber;
 };
 

--- a/init.sh
+++ b/init.sh
@@ -3,7 +3,7 @@ TOOLSPATH=/cvmfs/fcc.cern.ch/sw/0.8.3/tools/
 OS=`python $TOOLSPATH/hsf_get_platform.py --get os`
 
 # source FCC externals
-source /cvmfs/fcc.cern.ch/sw/views/releases/externals/93.0.0/x86_64-$OS-gcc62-opt/setup.sh
+source /cvmfs/fcc.cern.ch/sw/views/releases/externals/94.0.0/x86_64-$OS-gcc62-opt/setup.sh
 
 # Define path to podio
 # CMakeLists.txt relies on some environment variables

--- a/python/test_EventStore.py
+++ b/python/test_EventStore.py
@@ -9,7 +9,7 @@ from ROOT import ExampleHit, ConstExampleHit
 class EventStoreTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.filename = 'example.root'
+        self.filename = 'example1.root'
         self.assertTrue(os.path.isfile(self.filename))
         self.store = EventStore([self.filename])
 
@@ -114,7 +114,7 @@ if __name__ == "__main__":
     import os
     gSystem.Load("libTestDataModel")
     # creating example file for the tests
-    if not os.path.isfile('example.root'):
+    if not os.path.isfile('example1.root'):
         write = '{podio}/tests/write'.format(podio=os.environ['PODIO'])
         print write
         call(write)

--- a/src/PythonEventStore.cc
+++ b/src/PythonEventStore.cc
@@ -1,6 +1,7 @@
 #include "podio/PythonEventStore.h"
 
 #include <fstream>
+#include <string>
 #include <iostream>
 
 podio::PythonEventStore::PythonEventStore(const char* name) :
@@ -15,7 +16,7 @@ podio::PythonEventStore::PythonEventStore(const char* name) :
     m_isZombie = false;
   }
   if(! m_isZombie ) {
-    m_reader.openFile(name);
+    m_reader.openFiles({std::string(name)});
     m_store.setReader(&m_reader);
   }
 }

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -1,7 +1,9 @@
 // ROOT specific includes
 #include "TFile.h"
 #include "TTree.h"
+#include "TChain.h"
 #include "TROOT.h"
+#include "TTreeCache.h"
 
 // podio specific includes
 #include "podio/ROOTReader.h"
@@ -10,12 +12,6 @@
 
 namespace podio {
 
-  void ROOTReader::readCollectionIDTable(){
-    m_table = new CollectionIDTable();
-    auto metadatatree = static_cast<TTree*>(m_file->Get("metadata"));
-    metadatatree->SetBranchAddress("CollectionIDs",&m_table);
-    metadatatree->GetEntry(0);
-  }
 
   CollectionBase* ROOTReader::readCollection(const std::string& name) {
     // has the collection already been constructed?
@@ -24,9 +20,11 @@ namespace podio {
     if (p != end(m_inputs)){
       return p->first;
     }
-    // get the branches in the ROOT file
-    auto branch = m_eventTree->GetBranch(name.c_str());
-    if (branch == nullptr) return nullptr;
+    auto branch = m_chain->GetBranch(name.c_str());
+    if (nullptr == branch) {
+      return nullptr;
+    }
+
 
     // look for involved classes
     TClass* theClass(nullptr);
@@ -60,14 +58,22 @@ namespace podio {
     collection->setBuffer(buffer);
     branch->SetAddress(collection->getBufferAddress());
     m_inputs.emplace_back(std::make_pair(collection,name));
-    branch->GetEntry(m_eventNumber);
+    Long64_t localEntry = m_chain->LoadTree(m_eventNumber);
+    // After switching trees in the chain, branch pointers get invalidated
+    // so they need to be reassigned as well as addresses
+    if(localEntry == 0){
+        branch = m_chain->GetBranch(name.c_str());
+        branch->SetAddress(collection->getBufferAddress());
+    }
+    branch->GetEntry(localEntry);
     // load the collections containing references
     auto refCollections = collection->referenceCollections();
+
     if (refCollections != nullptr) {
       for (int i = 0, end = refCollections->size(); i!=end; ++i){
-        branch = m_eventTree->GetBranch((name+"#"+std::to_string(i)).c_str());
+        branch = m_chain->GetBranch((name+"#"+std::to_string(i)).c_str());
         branch->SetAddress(&(*refCollections)[i]);
-        branch->GetEntry(m_eventNumber);
+        branch->GetEntry(localEntry);
       }
     }
     auto id = m_table->collectionID(name);
@@ -76,21 +82,30 @@ namespace podio {
     return collection;
   }
 
-  void ROOTReader::openFile(const std::string& filename){
-    m_file = TFile::Open(filename.c_str(),"READ","data file");
-    if (m_file->IsZombie()) {
-      exit(-1);
+  void ROOTReader::openFiles(const std::vector<std::string>& filenames){
+    m_chain = new TChain("events");
+    for (const auto& filename:  filenames) {
+      m_chain->Add(filename.c_str());
     }
-    m_eventTree = static_cast<TTree*>( m_file->Get("events") );
-    readCollectionIDTable();
+    CollectionIDTable* l_table = new CollectionIDTable();
+    auto metadatatree = static_cast<TTree*>(m_chain->GetFile()->Get("metadata"));
+    metadatatree->SetBranchAddress("CollectionIDs",&l_table);
+    metadatatree->GetEntry(0);
+    auto l_names = l_table->names();
+    std::vector<int> l_collectionIDs;
+    for (auto name: l_names) {
+      l_collectionIDs.push_back(l_table->collectionID(name));
+
+    }
+    m_table = new CollectionIDTable(l_collectionIDs, l_names);
   }
 
-  void ROOTReader::closeFile() {
-    m_file->Close();
+  void ROOTReader::closeFiles() {
+    delete m_chain;
   }
 
   void ROOTReader::readEvent(){
-    m_eventTree->GetEntry();
+    m_chain->GetEntry(m_eventNumber);
     // first prepare all collections in memory...
     for(auto inputs : m_inputs){
       inputs.first->prepareAfterRead();
@@ -102,7 +117,7 @@ namespace podio {
   //  }
   }
   bool ROOTReader::isValid() const {
-    return m_file->IsOpen() && !m_file->IsZombie();
+    return m_chain->GetFile()->IsOpen() && !m_chain->GetFile()->IsZombie();
   }
 
   ROOTReader::~ROOTReader() {
@@ -117,7 +132,7 @@ namespace podio {
   }
 
   unsigned ROOTReader::getEntries() const {
-    return m_eventTree->GetEntries();
+    return m_chain->GetEntries();
   }
 
   void ROOTReader::goToEvent(unsigned eventNumber) {

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -39,11 +39,10 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
   } else {
     throw std::runtime_error("Collection 'strings' should be present.");
   }
-  //std::cout << "Fetching collection 'clusters'" << std::endl;
+
   auto& clusters = store.get<ExampleClusterCollection>("clusters");
   if(clusters.isValid()){
     auto cluster = clusters[0];
-    //std::cout << "Cluster has an energy of " << cluster.energy() << std::endl;
     for (auto i = cluster.Hits_begin(), end = cluster.Hits_end(); i!=end; ++i){
       std::cout << "  Referenced hit has an energy of " << i->energy() << std::endl;
       glob++;
@@ -201,7 +200,7 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
 int main(){
   auto reader = podio::ROOTReader();
   auto store = podio::EventStore();
-  reader.openFile("example.root");
+  reader.openFiles({"example2.root", "example1.root"});
   store.setReader(&reader);
 
   bool verbose = true;
@@ -210,9 +209,10 @@ int main(){
   for(unsigned i=0; i<nEvents; ++i) {
     if(i%1000==0)
       std::cout<<"reading event "<<i<<std::endl;
-    processEvent(store, true, i);
+    processEvent(store, true, i%(nEvents / 2));
     store.clear();
     reader.endOfEvent();
   }
+  reader.closeFiles();
   return 0;
 }

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -21,12 +21,11 @@
 #include "podio/EventStore.h"
 #include "podio/ROOTWriter.h"
 
-int main(){
-
+void write(std::string outfilename) {
   std::cout<<"start processing"<<std::endl;
 
   auto store = podio::EventStore();
-  auto writer = podio::ROOTWriter("example.root", &store);
+  auto writer = podio::ROOTWriter(outfilename, &store);
 
   auto& info       = store.create<EventInfoCollection>("info");
   auto& mcps       = store.create<ExampleMCCollection>("mcparticles");
@@ -237,4 +236,12 @@ int main(){
   }
 
   writer.finish();
+}
+
+
+int main(int argc, char* argv[]){
+  write("example1.root");
+  write("example2.root");
+
+
 }


### PR DESCRIPTION
This PR should allow for chaining podio input files. Mostly it is just a substitution TFile/TTree->TBranch, however I'm not sure about the following questions:
- What should the TChain report when asked for `isValid`? The status of all files in the chain, or the current one?  Furthermore I believe that zombie files are skipped automatically, so I don't know if those checks are still required.
- Should the TFile-based functions just be replaced with TChain? I went with "yes".
- The metadata tree is currently just read from the first file. Is this fine or do we need to check it is consistent across all input files? 

Fixes #3, a truly long-standing issue!
