### PR TITLE
Specify only those ROOT libraries required

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,11 +5,11 @@ file(GLOB headers ${CMAKE_SOURCE_DIR}/include/podio/*.h)
 REFLEX_GENERATE_DICTIONARY(podio ${headers} SELECTION selection.xml)
 add_library(podioDict SHARED podio.cxx)
 add_dependencies(podioDict podio-dictgen)
-target_link_libraries(podioDict podio ${ROOT_LIBRARIES})
+target_link_libraries(podioDict podio ROOT::Core)
 install(TARGETS podioDict DESTINATION lib)
 
 add_library(podio SHARED ${sources})
-target_link_libraries(podio ${ROOT_LIBRARIES})
+target_link_libraries(podio ROOT::RIO ROOT::Tree)
 install(TARGETS podio DESTINATION lib)
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/podio DESTINATION include)


### PR DESCRIPTION
Currently it uses the variable `ROOT_LIBRARIES` which basically adds all ROOT libraries. This leads to some errors with the master version of ROOT and hence for the upcoming version 6.16.