### PR TITLE
Workaround bug in REFLEX_GENERATE_DICTIONARY macro

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,10 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 
 file(GLOB sources *.cc)
 file(GLOB headers ${CMAKE_SOURCE_DIR}/include/podio/*.h)
-REFLEX_GENERATE_DICTIONARY(podio ${headers} SELECTION selection.xml)
+
+# OPTIONS paramaters are not redundant, it workarounds a bug on this macro
+# introduced by this commit: 3e88e1a6a2bd7fd9e495be3d900b41a45fd8bab
+REFLEX_GENERATE_DICTIONARY(podio ${headers} SELECTION selection.xml OPTIONS "-I${CMAKE_SOURCE_DIR}/include")
 add_library(podioDict SHARED podio.cxx)
 add_dependencies(podioDict podio-dictgen)
 target_link_libraries(podioDict podio ROOT::Core)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,10 @@ add_library(TestDataModel SHARED ${sources} ${sources_utils} ${headers} ${header
 target_link_libraries(TestDataModel podio )
 install(TARGETS TestDataModel DESTINATION tests)
 
-REFLEX_GENERATE_DICTIONARY(TestDataModel ${headers} SELECTION src/selection.xml)
+# OPTIONS paramaters are not redundant, it workarounds a bug on this macro
+# introduced by this commit: 3e88e1a6a2bd7fd9e495be3d900b41a45fd8bab 
+REFLEX_GENERATE_DICTIONARY(TestDataModel ${headers} SELECTION src/selection.xml
+                           OPTIONS "-I${CMAKE_SOURCE_DIR}/include" "-I${CMAKE_CURRENT_SOURCE_DIR}/datamodel")
 add_library(TestDataModelDict SHARED TestDataModel.cxx)
 add_dependencies(TestDataModelDict TestDataModel-dictgen)
 target_link_libraries(TestDataModelDict TestDataModel podio )


### PR DESCRIPTION
- Commit [3e88e1a6a2bd7fd9e495be3d900b41a45fd8bab](https://github.com/root-project/root/commit/3e88e1a6a2bd7fd9e495be3d900b41a45fd8bab7) in ROOT introduced a
regex that excludes build paths matching one the following words:

    ```
    AFTER|BEFORE|INTERFACE|PRIVATE|PUBLIC|SYSTEM
    ```

- Our current CI builds packages in a default path containing "FILESYSTEM"
which matches the regex above and hence fails since some include
diretories are excluded.

- This commit forces to include the directories excluded by the macro.