### PR TITLE
bump version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,9 @@
 cmake_minimum_required(VERSION 3.3)
 
 #--- Project name --------------------------------------------------------------
-project(podio)
+project(podio VERSION 0.9.1)
 
 #--- Version -------------------------------------------------------------------
-set( podio_VERSION_MAJOR 0 )
-set( podio_VERSION_MINOR 9 )
-set( podio_VERSION_PATCH 0 )
-set( podio_VERSION "${podio_VERSION_MAJOR}.${podio_VERSION_MINOR}" )
 
 #--- Define basic build settings -----------------------------------------------
 # Provides install directory variables as defined for GNU software


### PR DESCRIPTION

BEGINRELEASENOTES
- ROOTReader now supports multiple inputs thanks to new implementation based on TChain 
- ROOTReader now supports opening files via xrootd (`root:///eospublic.cern.ch//eos...` for example)
- Improved CMake and CPack configuration, sticking more closely to HSF template
ENDRELEASENOTES